### PR TITLE
Move tests into tests/ directory and add vitest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "files": [
     "index.ts",
     "src/**/*.ts",
-    "!src/**/*.test.ts",
     "LICENSE",
     "README.md"
   ],

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -5,7 +5,7 @@ import {
   formatGroupMeHistoryEntry,
   resolveGroupMeBodyForAgent,
   resolveGroupMeHistoryLimit,
-} from "./history.js";
+} from "../src/history.js";
 
 describe("resolveGroupMeHistoryLimit", () => {
   it("uses default when unset", () => {

--- a/tests/inbound.command-bypass.test.ts
+++ b/tests/inbound.command-bypass.test.ts
@@ -4,7 +4,7 @@ import type {
   CoreConfig,
   GroupMeCallbackData,
   ResolvedGroupMeAccount,
-} from "./types.js";
+} from "../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -60,11 +60,11 @@ const core = vi.hoisted(() => {
   };
 });
 
-vi.mock("./runtime.js", () => ({
+vi.mock("../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-import { handleGroupMeInbound } from "./inbound.js";
+import { handleGroupMeInbound } from "../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/inbound.history-buffer.test.ts
+++ b/tests/inbound.history-buffer.test.ts
@@ -4,7 +4,7 @@ import type {
   CoreConfig,
   GroupMeCallbackData,
   ResolvedGroupMeAccount,
-} from "./types.js";
+} from "../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -60,11 +60,11 @@ const core = vi.hoisted(() => {
   };
 });
 
-vi.mock("./runtime.js", () => ({
+vi.mock("../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-import { handleGroupMeInbound } from "./inbound.js";
+import { handleGroupMeInbound } from "../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/monitor.test.ts
+++ b/tests/monitor.test.ts
@@ -3,17 +3,17 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { RuntimeEnv } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
-import type { CoreConfig, ResolvedGroupMeAccount } from "./types.js";
+import type { CoreConfig, ResolvedGroupMeAccount } from "../src/types.js";
 
 const handleGroupMeInboundMock = vi.hoisted(() =>
   vi.fn(async (_params: unknown) => undefined),
 );
 
-vi.mock("./inbound.js", () => ({
+vi.mock("../src/inbound.js", () => ({
   handleGroupMeInbound: handleGroupMeInboundMock,
 }));
 
-import { createGroupMeWebhookHandler } from "./monitor.js";
+import { createGroupMeWebhookHandler } from "../src/monitor.js";
 
 async function withServer(
   handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeGroupMeGroupId,
   normalizeGroupMeTarget,
   normalizeGroupMeUserId,
-} from "./normalize.js";
+} from "../src/normalize.js";
 
 describe("groupme normalize", () => {
   it("normalizes user and group ids", () => {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -4,7 +4,7 @@ import {
   extractImageUrls,
   parseGroupMeCallback,
   shouldProcessCallback,
-} from "./parse.js";
+} from "../src/parse.js";
 
 const validPayload = {
   id: "msg-1",

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSenderAccess } from "./policy.js";
+import { resolveSenderAccess } from "../src/policy.js";
 
 describe("resolveSenderAccess", () => {
   it("allows all when allowFrom is empty", () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GroupMeRateLimiter } from "./rate-limit.js";
+import { GroupMeRateLimiter } from "../src/rate-limit.js";
 
 describe("GroupMeRateLimiter", () => {
   it("enforces per-ip threshold", () => {

--- a/tests/replay-cache.test.ts
+++ b/tests/replay-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GroupMeReplayCache } from "./replay-cache.js";
+import { GroupMeReplayCache } from "../src/replay-cache.js";
 
 describe("GroupMeReplayCache", () => {
   it("accepts first key and rejects duplicate within ttl", () => {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,8 +5,8 @@ import {
   resolveGroupMeSecurity,
   validateProxyRequest,
   verifyCallbackAuth,
-} from "./security.js";
-import type { GroupMeAccountConfig } from "./types.js";
+} from "../src/security.js";
+import type { GroupMeAccountConfig } from "../src/types.js";
 
 function buildSecurity(config?: GroupMeAccountConfig) {
   return resolveGroupMeSecurity(config ?? {});

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import type { CoreConfig } from "./types.js";
-import { setGroupMeRuntime } from "./runtime.js";
+import type { CoreConfig } from "../src/types.js";
+import { setGroupMeRuntime } from "../src/runtime.js";
 import {
   sendGroupMeMedia,
   sendGroupMeMessage,
   sendGroupMeText,
   uploadGroupMeImage,
-} from "./send.js";
+} from "../src/send.js";
 
 describe("sendGroupMeMessage", () => {
   it("sends text message", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["index.ts", "src/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Move all 11 test files from `src/` to `tests/`
- Add `vitest.config.ts` with explicit test include pattern
- Update imports in test files to reference `../src/` modules
- Update `tsconfig.json` to include `tests/` and `vitest.config.ts`
- Simplify `package.json` `files` field (test exclusion no longer needed)

## Test plan

- [x] All 84 tests pass (`npm test`)
- [x] Type-checking passes (`npm run typecheck`)
- [x] `npm pack --dry-run` confirms no test files in published package

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)