### PR TITLE
refactor: simplify codebase, reduce duplication

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -15,7 +15,7 @@ const ENV_BOT_NAME = "GROUPME_BOT_NAME";
 const ENV_CALLBACK_URL = "GROUPME_CALLBACK_URL";
 const ENV_GROUP_ID = "GROUPME_GROUP_ID";
 
-function readTrimmed(value: unknown): string | undefined {
+export function readTrimmed(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -47,32 +47,19 @@ function rejectDecision(params: {
   };
 }
 
+const STATUS_TEXT: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  405: "Method Not Allowed",
+  408: "Request Timeout",
+  413: "Payload Too Large",
+  429: "Too Many Requests",
+};
+
 function formatRejectionBody(status: number): string {
-  if (status === 404) {
-    return "Not Found";
-  }
-  if (status === 403) {
-    return "Forbidden";
-  }
-  if (status === 401) {
-    return "Unauthorized";
-  }
-  if (status === 429) {
-    return "Too Many Requests";
-  }
-  if (status === 400) {
-    return "Bad Request";
-  }
-  if (status === 405) {
-    return "Method Not Allowed";
-  }
-  if (status === 408) {
-    return "Request Timeout";
-  }
-  if (status === 413) {
-    return "Payload Too Large";
-  }
-  return "rejected";
+  return STATUS_TEXT[status] ?? "rejected";
 }
 
 function asRequestBodyErrorCode(

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,18 +1,6 @@
-function normalizeStringId(raw: string | number): string | undefined {
+export function normalizeStringId(raw: string | number): string | undefined {
   const normalized = String(raw).trim();
   return normalized || undefined;
-}
-
-export function normalizeGroupMeUserId(
-  raw: string | number,
-): string | undefined {
-  return normalizeStringId(raw);
-}
-
-export function normalizeGroupMeGroupId(
-  raw: string | number,
-): string | undefined {
-  return normalizeStringId(raw);
 }
 
 const TARGET_PREFIX_RE = /^(groupme:)?(user:|group:)?/i;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -88,11 +88,7 @@ function parseAttachment(entry: unknown): GroupMeAttachment | null {
     if (!url) {
       return null;
     }
-    const imageAttachment: GroupMeImageAttachment = {
-      type,
-      url,
-    };
-    return imageAttachment;
+    return { type, url } satisfies GroupMeImageAttachment;
   }
 
   if (type === "location") {
@@ -102,22 +98,15 @@ function parseAttachment(entry: unknown): GroupMeAttachment | null {
     if (!lat || !lng || !name) {
       return null;
     }
-    const locationAttachment: GroupMeLocationAttachment = {
-      type,
-      lat,
-      lng,
-      name,
-    };
-    return locationAttachment;
+    return { type, lat, lng, name } satisfies GroupMeLocationAttachment;
   }
 
   if (type === "mentions") {
-    const mentionsAttachment: GroupMeMentionsAttachment = {
+    return {
       type,
       user_ids: parseStringArray(entry.user_ids),
       loci: parseNumberMatrix(entry.loci),
-    };
-    return mentionsAttachment;
+    } satisfies GroupMeMentionsAttachment;
   }
 
   if (type === "emoji") {
@@ -125,12 +114,11 @@ function parseAttachment(entry: unknown): GroupMeAttachment | null {
     if (!placeholder) {
       return null;
     }
-    const emojiAttachment: GroupMeEmojiAttachment = {
+    return {
       type,
       placeholder,
       charmap: parseNumberMatrix(entry.charmap),
-    };
-    return emojiAttachment;
+    } satisfies GroupMeEmojiAttachment;
   }
 
   return {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,13 +1,13 @@
 import {
   normalizeGroupMeAllowEntry,
-  normalizeGroupMeUserId,
+  normalizeStringId,
 } from "./normalize.js";
 
 export function resolveSenderAccess(params: {
   senderId: string;
   allowFrom?: Array<string | number>;
 }): boolean {
-  const senderId = normalizeGroupMeUserId(params.senderId);
+  const senderId = normalizeStringId(params.senderId);
   if (!senderId) {
     return false;
   }

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -2,20 +2,19 @@ import { describe, expect, it } from "vitest";
 import {
   looksLikeGroupMeTargetId,
   normalizeGroupMeAllowEntry,
-  normalizeGroupMeGroupId,
   normalizeGroupMeTarget,
-  normalizeGroupMeUserId,
+  normalizeStringId,
 } from "../src/normalize.js";
 
 describe("groupme normalize", () => {
-  it("normalizes user and group ids", () => {
-    expect(normalizeGroupMeUserId(" 123 ")).toBe("123");
-    expect(normalizeGroupMeGroupId(456)).toBe("456");
+  it("normalizes string ids", () => {
+    expect(normalizeStringId(" 123 ")).toBe("123");
+    expect(normalizeStringId(456)).toBe("456");
   });
 
   it("returns undefined for empty IDs", () => {
-    expect(normalizeGroupMeUserId("   ")).toBeUndefined();
-    expect(normalizeGroupMeGroupId("")).toBeUndefined();
+    expect(normalizeStringId("   ")).toBeUndefined();
+    expect(normalizeStringId("")).toBeUndefined();
   });
 
   it("normalizes prefixed targets", () => {


### PR DESCRIPTION
## Summary

- Extract `positiveIntOrDefault()` helper in `security.ts`, replacing 8 repetitive 3-line numeric-default patterns
- Consolidate duplicate `readTrimmed()` — export from `accounts.ts`, remove copy in `security.ts`
- Replace `formatRejectionBody()` if-chain with `Record<number, string>` lookup in `monitor.ts`
- Simplify `extractPictureUrl()` and inline `buildGroupMeBotPostPayload()` in `send.ts`
- Simplify `readApiError`, `readGroupsResponse`, `readBotResponse` in `groupme-api.ts` with cleaner casts
- Use `satisfies` for direct returns in `parseAttachment()` in `parse.ts`
- Export `normalizeStringId` directly, remove trivial `normalizeGroupMeUserId`/`normalizeGroupMeGroupId` wrappers

Net reduction: -117 lines across 9 files.

Fixes #21

## Test plan

- [x] All 109 existing tests pass (`npm test`)
- [x] No type errors (`npm run typecheck`)
- [ ] Verify no behavioral changes in webhook pipeline, send, and normalize paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)