### PR TITLE
Fix plugin ID mismatch: use 'openclaw-groupme' instead of 'groupme'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import { groupmePlugin } from "./src/channel.js";
 import { setGroupMeRuntime } from "./src/runtime.js";
 
 const plugin = {
-  id: "groupme",
+  id: "openclaw-groupme",
   name: "GroupMe",
   description: "GroupMe channel plugin",
   configSchema: emptyPluginConfigSchema(),


### PR DESCRIPTION
Fixes #24

The plugin exported `id: "groupme"` but the OpenClaw config references it as `openclaw-groupme` (matching the package name). This caused `openclaw doctor` to report a mismatch and config validation to fail.

**Change:** `index.ts` plugin id `"groupme"` → `"openclaw-groupme"`

All 110 tests pass, typecheck clean.