### PR TITLE
Use 'groupme' as plugin id to align with OpenClaw channel resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import { groupmePlugin } from "./src/channel.js";
 import { setGroupMeRuntime } from "./src/runtime.js";
 
 const plugin = {
-  id: "openclaw-groupme",
+  id: "groupme",
   name: "GroupMe",
   description: "GroupMe channel plugin",
   configSchema: emptyPluginConfigSchema(),

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "openclaw-groupme",
+  "id": "groupme",
   "channels": ["groupme"],
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "./index.ts"
     ],
     "channel": {
-      "id": "openclaw-groupme",
+      "id": "groupme",
       "label": "GroupMe",
       "selectionLabel": "GroupMe (Bot API)",
       "blurb": "GroupMe bot webhook integration (group chats only)."


### PR DESCRIPTION
Fixes #28

Changes plugin id from `openclaw-groupme` to `groupme` in:
- `index.ts` — plugin export id
- `openclaw.plugin.json` — manifest id
- `package.json` — `openclaw.channel.id`

The npm package name stays `openclaw-groupme` (we don't own `groupme` on npm).

See #28 for the full technical analysis of why this is necessary.

All 110 tests pass, typecheck clean.