### PR TITLE
Enforce group ID validation in GroupMe security checks

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -174,7 +174,7 @@ async function decideWebhookRequest(params: {
   }
 
   const groupBinding = checkGroupBinding({
-    expectedGroupId: params.security.expectedGroupId,
+    groupId: params.security.groupId,
     inboundGroupId: message.groupId,
   });
   if (!groupBinding.ok) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,7 +19,7 @@ const IPV6_MAX_CIDR_PREFIX = 128;
 export type ResolvedGroupMeSecurity = {
   callbackToken: string;
   callbackRejectStatus: 404;
-  expectedGroupId: string;
+  groupId: string;
   replay: {
     enabled: boolean;
     ttlSeconds: number;
@@ -246,7 +246,7 @@ export function resolveGroupMeSecurity(
 ): ResolvedGroupMeSecurity {
   const security = (accountConfig.security ?? {}) as GroupMeSecurityConfig;
   const callbackToken = extractCallbackToken(accountConfig.callbackUrl);
-  const expectedGroupId = readTrimmed(accountConfig.groupId) ?? "";
+  const groupId = readTrimmed(accountConfig.groupId) ?? "";
 
   const allowedMimePrefixes = Array.isArray(security.media?.allowedMimePrefixes)
     ? security.media.allowedMimePrefixes
@@ -267,7 +267,7 @@ export function resolveGroupMeSecurity(
   return {
     callbackToken,
     callbackRejectStatus: 404,
-    expectedGroupId,
+    groupId,
     replay: {
       enabled: security.replay?.enabled !== false,
       ttlSeconds: positiveIntOrDefault(security.replay?.ttlSeconds, 600),
@@ -336,13 +336,10 @@ export function verifyCallbackAuth(params: {
 }
 
 export function checkGroupBinding(params: {
-  expectedGroupId: string;
+  groupId: string;
   inboundGroupId: string;
 }): { ok: true } | { ok: false; reason: "mismatch" } {
-  if (!params.expectedGroupId) {
-    return { ok: true };
-  }
-  if (params.expectedGroupId !== params.inboundGroupId) {
+  if (params.groupId !== params.inboundGroupId) {
     return { ok: false, reason: "mismatch" };
   }
   return { ok: true };

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -59,20 +59,20 @@ describe("verifyCallbackAuth", () => {
 });
 
 describe("checkGroupBinding", () => {
-  it("treats binding as disabled when expected group id is not configured", () => {
+  it("rejects when group id is not configured", () => {
     const security = buildSecurity({});
     expect(
       checkGroupBinding({
-        expectedGroupId: security.expectedGroupId,
+        groupId: security.groupId,
         inboundGroupId: "456",
       }),
-    ).toEqual({ ok: true });
+    ).toEqual({ ok: false, reason: "mismatch" });
   });
 
-  it("accepts expected group", () => {
+  it("accepts matching group", () => {
     expect(
       checkGroupBinding({
-        expectedGroupId: "123",
+        groupId: "123",
         inboundGroupId: "123",
       }),
     ).toEqual({ ok: true });
@@ -81,19 +81,19 @@ describe("checkGroupBinding", () => {
   it("rejects mismatch", () => {
     expect(
       checkGroupBinding({
-        expectedGroupId: "123",
+        groupId: "123",
         inboundGroupId: "456",
       }),
     ).toEqual({ ok: false, reason: "mismatch" });
   });
 
-  it("accepts when expected group id is missing", () => {
+  it("rejects when group id is empty", () => {
     expect(
       checkGroupBinding({
-        expectedGroupId: "",
+        groupId: "",
         inboundGroupId: "456",
       }),
-    ).toEqual({ ok: true });
+    ).toEqual({ ok: false, reason: "mismatch" });
   });
 });
 


### PR DESCRIPTION
## Summary
This change modifies the group binding validation logic to enforce that a group ID must be configured and must match the inbound group ID. Previously, missing or empty group IDs were treated as disabled/bypassed validation.

## Key Changes
- Renamed `expectedGroupId` to `groupId` throughout the codebase for clarity
- Changed `checkGroupBinding()` to reject requests when group ID is not configured (empty string), rather than treating it as a disabled check
- Updated the validation logic to always require a match between configured and inbound group IDs
- Updated all test cases to reflect the new stricter validation behavior

## Implementation Details
- The `checkGroupBinding()` function now treats an empty `groupId` the same as a mismatch, returning `{ ok: false, reason: "mismatch" }`
- This ensures that if a group ID is configured in security settings, it must match the incoming message's group ID
- The parameter rename from `expectedGroupId` to `groupId` makes the intent clearer and aligns with the configuration property name

https://claude.ai/code/session_01JTxCagrvoU9wfxQzLTvbCs