### PR TITLE
Simplify security config by removing `enabled` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The wizard will:
 - Let you select a group
 - Register a bot automatically
 - Generate a secure callback URL
-- Write config fields (`botId`, `groupId`, `publicDomain`, `callbackUrl`, security defaults)
+- Write config fields (`botId`, `groupId`, `publicDomain`, `callbackUrl`)
 
 4. Restart OpenClaw gateway:
 
@@ -94,35 +94,19 @@ channels:
     publicDomain: "bot.example.com"
     callbackUrl: "/groupme/e60b3e59da98950f?k=YOUR_SECRET"
     requireMention: true
-    historyLimit: 20
+```
+
+Security defaults (replay, rate limiting, media restrictions, logging) are applied automatically.
+To customize security or enable proxy validation, add a `security` block with only the fields you want to override:
+
+```yaml
     security:
-      replay:
-        enabled: true
-        ttlSeconds: 600
-        maxEntries: 10000
       rateLimit:
-        enabled: true
-        windowMs: 60000
-        maxRequestsPerIp: 120
-        maxRequestsPerSender: 60
-        maxConcurrent: 8
-      media:
-        allowPrivateNetworks: false
-        maxDownloadBytes: 15728640
-        requestTimeoutMs: 10000
-        allowedMimePrefixes: ["image/"]
-      logging:
-        redactSecrets: true
-        logRejectedRequests: true
-      commandBypass:
-        requireAllowFrom: true
-        requireMentionForCommands: false
+        maxRequestsPerIp: 60
       proxy:
-        enabled: false
-        trustedProxyCidrs: ["127.0.0.1/32", "::1/128"]
-        allowedPublicHosts: []
-        requireHttpsProto: false
-        rejectStatus: 403
+        trustedProxyCidrs: ["10.0.0.0/8"]
+        allowedPublicHosts: ["bot.example.com"]
+        requireHttpsProto: true
 ```
 
 ## Response modes
@@ -211,12 +195,12 @@ Set the bot callback in GroupMe to:
 
 ### Security config reference
 
+Replay protection and rate limiting are always enabled with safe defaults. Proxy validation is enabled by including a `proxy` block.
+
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `security.replay.enabled` | boolean | `true` | Enable replay dedupe |
 | `security.replay.ttlSeconds` | number | `600` | Replay dedupe TTL |
 | `security.replay.maxEntries` | number | `10000` | Replay cache size bound |
-| `security.rateLimit.enabled` | boolean | `true` | Enable webhook rate limiting |
 | `security.rateLimit.windowMs` | number | `60000` | Sliding window size |
 | `security.rateLimit.maxRequestsPerIp` | number | `120` | Max webhook requests per IP per window |
 | `security.rateLimit.maxRequestsPerSender` | number | `60` | Max webhook requests per sender per window |
@@ -229,7 +213,7 @@ Set the bot callback in GroupMe to:
 | `security.logging.logRejectedRequests` | boolean | `true` | Emit webhook rejection logs |
 | `security.commandBypass.requireAllowFrom` | boolean | `true` | Require `allowFrom` membership for command bypass |
 | `security.commandBypass.requireMentionForCommands` | boolean | `false` | Require mention even for control commands |
-| `security.proxy.enabled` | boolean | `false` | Enable trusted-proxy host/proto/client-IP validation |
+| `security.proxy` | object | — | Include to enable trusted-proxy host/proto/client-IP validation |
 | `security.proxy.trustedProxyCidrs` | string[] | `[]` | Trust forwarded headers only from these CIDRs |
 | `security.proxy.allowedPublicHosts` | string[] | `[]` | Allowed effective public hosts |
 | `security.proxy.requireHttpsProto` | boolean | `false` | Require effective protocol to be `https` |

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -8,7 +8,6 @@ const allowFromEntry = z.union([z.string(), z.number()]);
 
 const GroupMeReplaySchema = z
   .object({
-    enabled: z.boolean().optional().default(true),
     ttlSeconds: z.number().int().positive().optional(),
     maxEntries: z.number().int().positive().optional(),
   })
@@ -16,7 +15,6 @@ const GroupMeReplaySchema = z
 
 const GroupMeRateLimitSchema = z
   .object({
-    enabled: z.boolean().optional().default(true),
     windowMs: z.number().int().positive().optional(),
     maxRequestsPerIp: z.number().int().positive().optional(),
     maxRequestsPerSender: z.number().int().positive().optional(),
@@ -49,7 +47,6 @@ const GroupMeCommandBypassSecuritySchema = z
 
 const GroupMeProxySecuritySchema = z
   .object({
-    enabled: z.boolean().optional().default(false),
     trustedProxyCidrs: z.array(z.string()).optional(),
     allowedPublicHosts: z.array(z.string()).optional(),
     requireHttpsProto: z.boolean().optional().default(false),

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -225,41 +225,6 @@ export const groupmeOnboardingAdapter: ChannelOnboardingAdapter = {
         publicDomain,
         callbackUrl,
         requireMention,
-        security: {
-          replay: {
-            enabled: true,
-            ttlSeconds: 600,
-            maxEntries: 10_000,
-          },
-          rateLimit: {
-            enabled: true,
-            windowMs: 60_000,
-            maxRequestsPerIp: 120,
-            maxRequestsPerSender: 60,
-            maxConcurrent: 8,
-          },
-          media: {
-            allowPrivateNetworks: false,
-            maxDownloadBytes: 15 * 1024 * 1024,
-            requestTimeoutMs: 10_000,
-            allowedMimePrefixes: ["image/"],
-          },
-          logging: {
-            redactSecrets: true,
-            logRejectedRequests: true,
-          },
-          commandBypass: {
-            requireAllowFrom: true,
-            requireMentionForCommands: false,
-          },
-          proxy: {
-            enabled: false,
-            trustedProxyCidrs: ["127.0.0.1/32", "::1/128"],
-            allowedPublicHosts: [],
-            requireHttpsProto: false,
-            rejectStatus: 403,
-          },
-        },
       },
     });
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -269,12 +269,12 @@ export function resolveGroupMeSecurity(
     callbackRejectStatus: 404,
     expectedGroupId,
     replay: {
-      enabled: security.replay?.enabled !== false,
+      enabled: true,
       ttlSeconds: positiveIntOrDefault(security.replay?.ttlSeconds, 600),
       maxEntries: positiveIntOrDefault(security.replay?.maxEntries, 10_000),
     },
     rateLimit: {
-      enabled: security.rateLimit?.enabled !== false,
+      enabled: true,
       windowMs: positiveIntOrDefault(security.rateLimit?.windowMs, 60_000),
       maxRequestsPerIp: positiveIntOrDefault(security.rateLimit?.maxRequestsPerIp, 120),
       maxRequestsPerSender: positiveIntOrDefault(security.rateLimit?.maxRequestsPerSender, 60),
@@ -297,7 +297,7 @@ export function resolveGroupMeSecurity(
         security.commandBypass?.requireMentionForCommands === true,
     },
     proxy: {
-      enabled: security.proxy?.enabled === true,
+      enabled: security.proxy != null,
       trustedProxyCidrs,
       allowedPublicHosts,
       requireHttpsProto: security.proxy?.requireHttpsProto === true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,13 +7,11 @@ import type {
 export type GroupMeAllowFromEntry = string | number;
 
 export type GroupMeReplayConfig = {
-  enabled?: boolean;
   ttlSeconds?: number;
   maxEntries?: number;
 };
 
 export type GroupMeRateLimitConfig = {
-  enabled?: boolean;
   windowMs?: number;
   maxRequestsPerIp?: number;
   maxRequestsPerSender?: number;
@@ -38,7 +36,6 @@ export type GroupMeCommandBypassSecurityConfig = {
 };
 
 export type GroupMeProxySecurityConfig = {
-  enabled?: boolean;
   trustedProxyCidrs?: string[];
   allowedPublicHosts?: string[];
   requireHttpsProto?: boolean;

--- a/tests/monitor.test.ts
+++ b/tests/monitor.test.ts
@@ -93,12 +93,10 @@ function buildAccount(
       callbackUrl: "/groupme?k=secret-token",
       security: {
         replay: {
-          enabled: true,
           ttlSeconds: 600,
           maxEntries: 1000,
         },
         rateLimit: {
-          enabled: true,
           windowMs: 60_000,
           maxRequestsPerIp: 120,
           maxRequestsPerSender: 60,
@@ -287,7 +285,6 @@ describe("createGroupMeWebhookHandler", () => {
         security: {
           ...buildAccount().config.security,
           rateLimit: {
-            enabled: true,
             windowMs: 60_000,
             maxRequestsPerIp: 120,
             maxRequestsPerSender: 1,
@@ -333,7 +330,6 @@ describe("createGroupMeWebhookHandler", () => {
         security: {
           ...buildAccount().config.security,
           proxy: {
-            enabled: true,
             trustedProxyCidrs: ["127.0.0.1/32"],
             allowedPublicHosts: ["bot.example.com"],
             requireHttpsProto: true,
@@ -377,7 +373,6 @@ describe("createGroupMeWebhookHandler", () => {
         security: {
           ...buildAccount().config.security,
           proxy: {
-            enabled: true,
             trustedProxyCidrs: ["127.0.0.1/32"],
             allowedPublicHosts: ["bot.example.com"],
             rejectStatus: 403,
@@ -417,12 +412,10 @@ describe("createGroupMeWebhookHandler", () => {
         security: {
           ...buildAccount().config.security,
           proxy: {
-            enabled: true,
             trustedProxyCidrs: ["203.0.113.9/32"],
             rejectStatus: 403,
           },
           rateLimit: {
-            enabled: true,
             windowMs: 60_000,
             maxRequestsPerIp: 1,
             maxRequestsPerSender: 20,

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -140,7 +140,6 @@ describe("validateProxyRequest", () => {
     const security = buildSecurity({
       security: {
         proxy: {
-          enabled: true,
           trustedProxyCidrs: ["127.0.0.1/32"],
           allowedPublicHosts: ["bot.example.com"],
           requireHttpsProto: true,
@@ -173,7 +172,6 @@ describe("validateProxyRequest", () => {
     const security = buildSecurity({
       security: {
         proxy: {
-          enabled: true,
           trustedProxyCidrs: ["127.0.0.1/32"],
           allowedPublicHosts: ["bot.example.com"],
           rejectStatus: 403,
@@ -200,7 +198,6 @@ describe("validateProxyRequest", () => {
     const security = buildSecurity({
       security: {
         proxy: {
-          enabled: true,
           trustedProxyCidrs: ["127.0.0.1/32"],
           requireHttpsProto: true,
           rejectStatus: 400,


### PR DESCRIPTION
## Summary
- Remove `enabled` field from `replay`, `rateLimit`, and `proxy` security subsystem types, Zod schemas, and test fixtures
- Replay and rate limiting are now always on with safe defaults; proxy is enabled by presence of the `proxy` block
- Onboarding no longer writes a verbose security block — everything uses defaults
- Update README config examples and security reference table

Fixes #31

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 110 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)