### PR TITLE
[codex] add ClawHub package publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Chicago
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Chicago
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Check npm package contents
+        run: npm pack --dry-run

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,37 +12,51 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
 
+  publish-npm:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
-        if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
         run: npm ci
 
       - name: Type-check
-        if: ${{ steps.release.outputs.release_created }}
         run: npm run typecheck
 
       - name: Run tests
-        if: ${{ steps.release.outputs.release_created }}
         run: npm test
 
       - name: Show package version
-        if: ${{ steps.release.outputs.release_created }}
         run: npm pkg get name version
 
       - name: Publish package
-        if: ${{ steps.release.outputs.release_created }}
         run: npm publish --provenance --access public
+
+  publish-clawhub:
+    needs:
+      - release-please
+      - publish-npm
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    with:
+      dry_run: false
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **openclaw-groupme**, an OpenClaw channel plugin that connects GroupMe group chats to OpenClaw agents via webhooks. It receives inbound messages from GroupMe's callback API, routes them through a security pipeline, and dispatches replies back through the GroupMe Bot API.
+
+The plugin is published to npm as `openclaw-groupme` and loaded by the OpenClaw runtime via the `openclaw.extensions` field in `package.json`, which points to `./index.ts`. OpenClaw runs the TypeScript directly — there is no build step.
+
+## Commands
+
+```bash
+npm test                              # Run all tests (vitest)
+npm run typecheck                     # Type-check with tsc --noEmit
+npx vitest run tests/parse.test.ts    # Run a single test file
+npx vitest run -t "accepts active"    # Run tests matching a name pattern
+```
+
+## Architecture
+
+### Plugin Entry Point
+
+`index.ts` registers the plugin with OpenClaw. It captures the `PluginRuntime` into a module-level singleton (`src/runtime.ts`) and registers the channel plugin object defined in `src/channel.ts`.
+
+### Inbound Webhook Pipeline
+
+When a GroupMe callback hits the webhook, `src/monitor.ts` runs a sequential decision pipeline via `decideWebhookRequest()`:
+
+1. **Method check** — reject non-POST (405)
+2. **Callback token auth** (`src/security.ts`) — timing-safe token verification
+3. **Proxy validation** (`src/security.ts`) — CIDR-based trusted proxy, host allowlist
+4. **Body parsing** — 64KB limit, 15s timeout
+5. **Payload parsing** (`src/parse.ts`) — extract `GroupMeCallbackData`
+6. **Message filtering** (`src/parse.ts`) — ignore bots, system messages, empty messages
+7. **Group binding** (`src/security.ts`) — enforce expected group_id
+8. **Replay dedup** (`src/replay-cache.ts`) — SHA256-keyed sliding TTL cache
+9. **Rate limiting** (`src/rate-limit.ts`) — per-IP, per-sender, and global concurrency
+
+After acceptance, the response is sent immediately (`200 ok`) and `src/inbound.ts` handles processing asynchronously:
+- Sender access control via `allowFrom` (`src/policy.ts`)
+- Mention detection with botName, regex patterns, and agent regexes (`src/parse.ts`)
+- History buffering for `requireMention: true` mode (`src/history.ts`)
+- Control command gating with configurable bypass security
+- Session recording and reply dispatch via OpenClaw runtime APIs
+
+### Outbound
+
+`src/send.ts` handles sending messages back to GroupMe:
+- Text messages via the Bot API (`/v3/bots/post`)
+- Media: download remote image (with SSRF guard + MIME + size limits) → upload to GroupMe Image Service → send with `picture_url`
+- Uses `runtime.channel.media.fetchRemoteMedia` when available, falls back to built-in `fetchWithSsrFGuard`
+
+### Configuration
+
+`src/types.ts` defines all config types. `src/config-schema.ts` provides Zod validation. `src/accounts.ts` handles multi-account resolution with config inheritance and env var fallback (`GROUPME_BOT_ID`, `GROUPME_ACCESS_TOKEN`, etc.).
+
+`src/security.ts` exports `resolveGroupMeSecurity()` which merges user config with secure defaults (replay enabled, rate limiting enabled, private networks blocked, secrets redacted).
+
+### Onboarding
+
+`src/onboarding.ts` implements the `ChannelOnboardingAdapter` for interactive bot setup. It uses `src/groupme-api.ts` to call the GroupMe REST API (`fetchGroups`, `createBot`) and guides the user through group selection and bot creation.
+
+### Utilities
+
+`src/normalize.ts` provides ID normalization helpers (`normalizeStringId`, `normalizeGroupMeTarget`, `looksLikeGroupMeTargetId`) used across config resolution and policy matching.
+
+### Key Patterns
+
+- **All imports use `.js` extensions** — required by Node16 module resolution (`"type": "module"`)
+- **Security config uses a "resolve with defaults" pattern** — `resolveGroupMeSecurity()` fills in all defaults so downstream code never handles `undefined` security fields
+- **`PluginRuntime` is accessed via `getGroupMeRuntime()`** — a module-level singleton set once at plugin registration; test files mock `src/runtime.ts` to inject fakes
+- **Tests that use `vi.mock()` must mock the `src/` path** — e.g., `vi.mock("../src/runtime.js", ...)`
+- **`FetchLike` is defined as an explicit function signature**, not `typeof fetch` (newer Node types add static properties to `fetch` that break assignability)
+
+## Reference Docs
+
+`docs/references/` contains local copies of GroupMe's developer documentation. Consult these when working on API integration code (e.g., `src/send.ts`, `src/accounts.ts`) rather than guessing endpoint details:
+
+- **`groupme-api-reference.md`** — Full REST API reference (groups, members, messages, bots, etc.). Use when adding or modifying API calls.
+- **`groupme-image-service-reference.md`** — Image Service upload/download API. Use when working on media handling in `src/send.ts`.
+- **`groupme-bot-tutorial.md`** — Bot registration, callback setup, and posting tutorial. Use for understanding bot lifecycle and webhook configuration.
+
+## Commit Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Release Please reads commit messages to determine version bumps and generate changelogs.
+
+**Format:** `<type>: <description>` (lowercase type, imperative description)
+
+| Type | Version bump | Use for |
+|------|-------------|---------|
+| `feat:` | minor (0.x.0) | New features or capabilities |
+| `fix:` | patch (0.0.x) | Bug fixes |
+| `feat!:` or `BREAKING CHANGE:` footer | major (x.0.0) | Breaking API/config changes |
+| `docs:` | none | Documentation only |
+| `ci:` | none | CI/CD workflow changes |
+| `chore:` | none | Maintenance, deps, tooling |
+| `refactor:` | none | Code changes that don't fix bugs or add features |
+| `test:` | none | Adding or updating tests |
+
+Only `feat:`, `fix:`, and breaking changes trigger a release. Use the appropriate type so the changelog and version bump are correct.
+
+## ClawHub Publishing
+
+This is a ClawHub **code plugin**, not a skills plugin. Use `clawhub package publish` semantics and the official reusable package workflow:
+
+```yaml
+uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+```
+
+Do not add the `clawhub` CLI as a root dev dependency just to publish releases. Its tooling dependencies have higher Node engine requirements than this package's runtime `engines.node: ">=18"` contract, so keeping it out of the root package avoids surprising contributors and consumers.
+
+For local ClawHub commands, use `npx` or `pnx` instead of requiring a global install:
+
+```bash
+npx --yes clawhub package publish ./openclaw-groupme-0.4.1.tgz --family code-plugin --dry-run
+```
+
+ClawHub install docs should prefer:
+
+```bash
+openclaw plugins install clawhub:openclaw-groupme
+```
+
+Keep the npm install path documented as an explicit alternative:
+
+```bash
+openclaw plugins install npm:openclaw-groupme
+```
+
+## Dependencies
+
+- **`zod`** (runtime) — config schema validation
+- **`openclaw`** (peer) — plugin SDK, runtime APIs, security utilities (`fetchWithSsrFGuard`, `readJsonBodyWithLimit`, etc.)
+- **`vitest`** (dev) — test framework
+- **`typescript`** (dev) — type-checking only (no compilation)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ An [OpenClaw](https://github.com/oddrationale/openclaw) channel plugin that brin
 ## Install
 
 ```bash
-openclaw plugins install openclaw-groupme
+openclaw plugins install clawhub:openclaw-groupme
+```
+
+You can also install directly from npm if you want npm to be the explicit source:
+
+```bash
+openclaw plugins install npm:openclaw-groupme
 ```
 
 After installing, restart the gateway so it picks up the new plugin:

--- a/package-lock.json
+++ b/package-lock.json
@@ -952,26 +952,33 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
-      "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
+      "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.0.1",
-        "picocolors": "^1.0.0",
+        "@clack/core": "1.3.1",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -7560,6 +7567,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7576,6 +7600,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "5.3.6",
@@ -8109,9 +8143,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10990,9 +11024,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12052,9 +12086,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
     "extensions": [
       "./index.ts"
     ],
+    "compat": {
+      "pluginApi": ">=2026.2.26"
+    },
+    "build": {
+      "openclawVersion": "2026.2.26"
+    },
     "channel": {
       "id": "groupme",
       "label": "GroupMe",


### PR DESCRIPTION
## Summary

Adds ClawHub publishing support for the existing `openclaw-groupme` code plugin package.

## Changes

- Adds required `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` metadata for ClawHub code-plugin publishing.
- Updates README install docs to prefer `clawhub:openclaw-groupme` while preserving `npm:openclaw-groupme` as an explicit alternative.
- Extends the Release Please workflow to pack the npm artifact and publish it to ClawHub after npm publish succeeds.
- Adds `npm pack --dry-run` to CI to catch package contents regressions.

## Validation

- `npm run typecheck`
- `npm test`
- `npm pack --dry-run`

## Follow-up

`CLAWHUB_TOKEN` still needs to be added as a GitHub Actions secret. I tried `npx --yes clawhub login`, but the local auth flow timed out in this environment, so I could not pipe the token into `gh secret set CLAWHUB_TOKEN`.