### PR TITLE
fix: authenticate ClawHub publish in CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,6 +68,7 @@ jobs:
             echo "::error::CLAWHUB_TOKEN secret is required to publish to ClawHub."
             exit 1
           fi
+          npx --yes clawhub@0.19.1 login --token "${CLAWHUB_TOKEN}"
           npx --yes clawhub@0.19.1 package publish "${{ steps.pack.outputs.tarball }}" \
             --family code-plugin \
             --source-repo "${GITHUB_REPOSITORY}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,9 @@ Do not add the `clawhub` CLI as a root dev dependency just to publish releases. 
 For release automation, pack first and publish the generated tarball with a pinned CLI version:
 
 ```bash
-npm pack
+TARBALL="$(npm pack)"
 npx --yes clawhub@0.19.1 login --token "$CLAWHUB_TOKEN"
-npx --yes clawhub@0.19.1 package publish ./openclaw-groupme-0.4.1.tgz --family code-plugin --manual-override-reason "GitHub Actions release publish via CLAWHUB_TOKEN"
+npx --yes clawhub@0.19.1 package publish "./${TARBALL}" --family code-plugin --manual-override-reason "GitHub Actions release publish via CLAWHUB_TOKEN"
 ```
 
 For local ClawHub commands, use `npx` or `pnx` instead of requiring a global install:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ For release automation, pack first and publish the generated tarball with a pinn
 
 ```bash
 npm pack
+npx --yes clawhub@0.19.1 login --token "$CLAWHUB_TOKEN"
 npx --yes clawhub@0.19.1 package publish ./openclaw-groupme-0.4.1.tgz --family code-plugin --manual-override-reason "GitHub Actions release publish via CLAWHUB_TOKEN"
 ```
 


### PR DESCRIPTION
## Summary
- run pinned `clawhub@0.19.1 login --token "$CLAWHUB_TOKEN"` before publishing to ClawHub
- keep the existing explicit missing-secret check
- update AGENTS.md release guidance with the required CI login command

## Root cause
The 0.4.3 release package passed ClawHub package preparation, but `clawhub package publish` failed with `Not logged in. Run: clawhub login`. The CLI sees `CLAWHUB_TOKEN` in the environment but does not automatically treat it as an authenticated session.

## Verification
- `npx --yes clawhub@0.19.1 login --help` confirms `--token <token>` is supported
- `npm run typecheck`
- `npm test`
- `npm pack --dry-run`