### PR TITLE
ci: pin GitHub Actions by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "24 9 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
 
   publish-npm:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5
         id: release
 
   publish-npm:
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest published version of `openclaw-groupme`.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities through GitHub private vulnerability reporting:
+
+https://github.com/oddrationale/openclaw-groupme/security/advisories/new
+
+If private reporting is unavailable, open a GitHub issue with a high-level description only and avoid posting exploit details, secrets, tokens, callback URLs, or personal data. I will follow up privately when needed.
+
+## Scope
+
+Reports are especially helpful when they involve:
+
+- GroupMe webhook authentication or replay handling
+- SSRF, media download, or image upload handling
+- Access control, mention detection, or command bypass behavior
+- Secret handling and redaction
+- OpenClaw plugin registration or configuration parsing
+
+## Response
+
+I will acknowledge valid reports as soon as practical, investigate impact, and publish a patched release when a fix is available.


### PR DESCRIPTION
## Summary
- pin all external workflow actions to full commit SHAs
- add `SECURITY.md` so GitHub enables the repository security policy after merge
- add CodeQL code scanning for JavaScript/TypeScript
- add Dependency Review for dependency-changing pull requests
- confirm Dependabot has weekly `github-actions` updates for `.github/workflows`

## Repository security settings enabled with gh
- Dependabot alerts: enabled
- Dependabot security updates: enabled
- Private vulnerability reporting: enabled
- Secret scanning: already enabled
- Secret scanning push protection: already enabled
- GitHub Actions default token permissions: read-only
- GitHub Actions PR approval by workflows: disabled
- GitHub Actions SHA pinning policy: enabled

## Branch rules checked/updated with gh
- `main` is governed by an active repository ruleset, not classic branch protection
- branch deletion blocked
- force pushes blocked
- pull requests required
- squash merge required by ruleset
- linear history required
- Copilot code review enabled on push
- newly added required status checks: `test`, `Analyze JavaScript and TypeScript`, `CodeQL`, `dependency-review`
- required checks use strict/latest-code policy

Left unchanged intentionally: 0 required human approvals and the repository-admin bypass. Those are reasonable for a solo-maintained repo, but can be tightened later if desired.

GitHub accepted but did not enable non-provider secret patterns or secret validity checks; they still report disabled in `security_and_analysis`, so they appear unavailable for this repo/account tier right now.

## Pinned actions
- `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10` (`v6`)
- `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (`v6`)
- `googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062` (`v5`)
- `github/codeql-action/*@8aad20d150bbac5944a9f9d289da16a4b0d87c1e` (`v4`)
- `actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294` (`v5.0.0`)

## Verification
- resolved action tag refs with `gh api`
- scanned `.github/workflows/*.yml` for `uses:` entries
- confirmed `.github/dependabot.yml` includes weekly `github-actions` updates on Monday 09:00 America/Chicago
- verified repo security settings with `gh api repos/oddrationale/openclaw-groupme`
- verified ruleset with `gh api repos/oddrationale/openclaw-groupme/rulesets/12844212`
- confirmed PR #52 has all required checks passing
- `git diff --check`

Note: enabling Dependabot alerts surfaced existing default-branch dependency findings in GitHub Security. Those should be triaged separately from this hardening PR.