### PR TITLE
test: add integration and live smoke suites

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -29,8 +29,15 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run live smoke tests
-        run: npm run test:live
+      - name: Run GroupMe API live smoke
+        run: npm run test:live:api
+        env:
+          GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
+          GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}
+          GROUPME_LIVE_GROUP_ID: ${{ secrets.GROUPME_LIVE_GROUP_ID }}
+
+      - name: Run plugin outbound live smoke
+        run: npm run test:live:plugin-outbound
         env:
           GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
           GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,37 @@
+name: Live Smoke
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: groupme-live-smoke
+  cancel-in-progress: false
+
+jobs:
+  groupme-live:
+    runs-on: ubuntu-latest
+    if: github.repository == 'oddrationale/openclaw-groupme'
+    environment: groupme-live-smoke
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run live smoke tests
+        run: npm run test:live
+        env:
+          GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
+          GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}
+          GROUPME_LIVE_GROUP_ID: ${{ secrets.GROUPME_LIVE_GROUP_ID }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ That runs:
 
 - `npm run lint`
 - `npm run typecheck`
-- `npm test`
+- `npm run test:unit`
+- `npm run test:integration`
 - `npm run build`
 - `npm run knip`
 
@@ -36,10 +37,13 @@ npm run lint:fix
 npm run format
 npm run typecheck
 npm test
+npm run test:unit
+npm run test:integration
 npm run test:coverage
+npm run test:live
 npm run test:watch
 npm run build
-npx vitest run tests/parse.test.ts
+npx vitest run tests/unit/parse.test.ts
 npx vitest run -t "accepts active"
 ```
 

--- a/docs/2026-06-06-integration-testing-plan.md
+++ b/docs/2026-06-06-integration-testing-plan.md
@@ -24,9 +24,9 @@ Implemented in this branch:
 - GroupMe HTTP boundary tests use local HTTP servers to verify request method, path, query, headers, and JSON/body shape for group listing, bot creation, outbound bot posts, and image uploads.
 - Webhook-flow integration tests mount the real webhook handler on a local HTTP server and move accepted callbacks through the real inbound/session/dispatch path with a fake OpenClaw runtime.
 - Onboarding HTTP-boundary tests run the real setup wizard adapter against fake GroupMe `/groups` and `/bots` endpoints.
-- OpenClaw CLI smoke tests pack the plugin, install it into an isolated temporary OpenClaw home, and inspect it through `openclaw plugins inspect --json --runtime groupme`.
+- OpenClaw CLI smoke tests pack the plugin, install it into an isolated temporary OpenClaw home, inspect it through `openclaw plugins inspect --json --runtime groupme`, configure it with `openclaw channels add`, verify channel status/listing, and dry-run `openclaw message send --channel groupme`.
 - Live smoke tests live under `tests/live/`, skip without credentials, and post to GroupMe only when explicitly run with the live secrets.
-- A manual-only `Live Smoke` GitHub Actions workflow runs `npm run test:live` with the `groupme-live-smoke` environment and a concurrency guard.
+- A manual-only `Live Smoke` GitHub Actions workflow runs the GroupMe API live smoke first, then the plugin outbound live smoke, with the `groupme-live-smoke` environment and a concurrency guard.
 
 Still good candidates for later expansion:
 
@@ -274,14 +274,17 @@ Planned structure:
 ```text
 tests/
   live/
-    groupme-live.test.ts
+    groupme-api-live.test.ts
+    groupme-plugin-outbound-live.test.ts
 ```
 
 Recommended scripts:
 
 ```json
 {
-  "test:live": "vitest run tests/live"
+  "test:live": "vitest run tests/live",
+  "test:live:api": "vitest run tests/live/groupme-api-live.test.ts",
+  "test:live:plugin-outbound": "vitest run tests/live/groupme-plugin-outbound-live.test.ts"
 }
 ```
 
@@ -328,7 +331,13 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run test:live
+      - run: npm run test:live:api
+        env:
+          GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
+          GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}
+          GROUPME_LIVE_GROUP_ID: ${{ secrets.GROUPME_LIVE_GROUP_ID }}
+
+      - run: npm run test:live:plugin-outbound
         env:
           GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
           GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}
@@ -366,6 +375,8 @@ Recommended script shape:
   "test:unit": "vitest run tests/unit",
   "test:integration": "vitest run tests/integration",
   "test:live": "vitest run tests/live",
+  "test:live:api": "vitest run tests/live/groupme-api-live.test.ts",
+  "test:live:plugin-outbound": "vitest run tests/live/groupme-plugin-outbound-live.test.ts",
   "test:coverage": "vitest run tests/unit tests/integration --coverage"
 }
 ```
@@ -457,7 +468,8 @@ Acceptance criteria:
 
 ### Phase 6: Live Smoke Test
 
-- Add `tests/live/groupme-live.test.ts`.
+- Add `tests/live/groupme-api-live.test.ts`.
+- Add `tests/live/groupme-plugin-outbound-live.test.ts`.
 - Add manual `Live Smoke` GitHub Actions workflow.
 - Store secrets in GitHub Actions environment/repository secrets.
 - Start with outbound text send only.

--- a/docs/2026-06-06-integration-testing-plan.md
+++ b/docs/2026-06-06-integration-testing-plan.md
@@ -22,14 +22,17 @@ Implemented in this branch:
 - Install smoke tests pack the plugin, install it into a clean temporary project with OpenClaw, and import the installed runtime/setup/channel/secret sidecars.
 - Plugin contract tests import the built entrypoints and assert the GroupMe channel capability, setup adapter, secret contract, and config schema runtime contract.
 - GroupMe HTTP boundary tests use local HTTP servers to verify request method, path, query, headers, and JSON/body shape for group listing, bot creation, outbound bot posts, and image uploads.
+- Webhook-flow integration tests mount the real webhook handler on a local HTTP server and move accepted callbacks through the real inbound/session/dispatch path with a fake OpenClaw runtime.
+- Onboarding HTTP-boundary tests run the real setup wizard adapter against fake GroupMe `/groups` and `/bots` endpoints.
+- OpenClaw CLI smoke tests pack the plugin, install it into an isolated temporary OpenClaw home, and inspect it through `openclaw plugins inspect --json --runtime groupme`.
 - Live smoke tests live under `tests/live/`, skip without credentials, and post to GroupMe only when explicitly run with the live secrets.
 - A manual-only `Live Smoke` GitHub Actions workflow runs `npm run test:live` with the `groupme-live-smoke` environment and a concurrency guard.
 
 Still good candidates for later expansion:
 
-- A deeper webhook-flow integration test that runs the full inbound path with a richer fake OpenClaw runtime instead of the existing focused unit-level webhook server tests.
-- A full onboarding wizard integration test backed by local fake HTTP endpoints rather than the current API-boundary tests and mocked unit onboarding tests.
-- OpenClaw CLI `plugins install` / `plugins inspect --json --runtime groupme` smoke tests once a stable isolated OpenClaw profile setup is documented for CI.
+- A richer reply-delivery webhook test that lets the fake OpenClaw runtime call the reply `deliver` callback against a fake GroupMe Bot API.
+- A `configureWhenConfigured` onboarding integration path for changing groups and registering a replacement bot.
+- Optional live image upload or bot creation/deletion smoke tests, kept separate from the basic outbound-send live check.
 
 ## Test Categories
 
@@ -90,6 +93,7 @@ tests/
   integration/
     package-contract.test.ts
     install-smoke.test.ts
+    openclaw-cli-smoke.test.ts
     plugin-contract.test.ts
     webhook-flow.test.ts
     groupme-http-boundary.test.ts

--- a/docs/2026-06-06-integration-testing-plan.md
+++ b/docs/2026-06-06-integration-testing-plan.md
@@ -1,0 +1,454 @@
+# Integration Testing Plan
+
+Date: 2026-06-06
+
+## Goal
+
+Build confidence that `openclaw-groupme` installs, loads, and behaves correctly across three test categories:
+
+1. Unit Tests
+2. Integration Tests
+3. Live Smoke Tests
+
+The intent is to keep normal CI deterministic and credential-free while still providing an optional path to verify real GroupMe behavior before releases.
+
+## Test Categories
+
+### 1. Unit Tests
+
+Unit tests cover isolated behavior inside a single module or narrow collaboration boundary. They should be fast, deterministic, and free of real network calls.
+
+Planned structure:
+
+```text
+tests/
+  unit/
+    accounts.test.ts
+    channel.test.ts
+    config-schema.test.ts
+    groupme-api.test.ts
+    history.test.ts
+    inbound.*.test.ts
+    monitor.test.ts
+    normalize.test.ts
+    onboarding.test.ts
+    parse.test.ts
+    policy.test.ts
+    rate-limit.test.ts
+    replay-cache.test.ts
+    secret-contract.test.ts
+    security.test.ts
+    send.test.ts
+    setup.test.ts
+```
+
+Migration tasks:
+
+- Move all current test files from `tests/*.test.ts` into `tests/unit/`.
+- Update relative imports from `../src/...` to `../../src/...`.
+- Keep the current `npm test` behavior focused on unit tests at first.
+- Preserve current coverage thresholds and coverage reporting.
+- Keep existing focused tests useful; do not replace behavior assertions with broad snapshots.
+
+Recommended script updates:
+
+```json
+{
+  "test": "vitest run tests/unit",
+  "test:unit": "vitest run tests/unit",
+  "test:coverage": "vitest run tests/unit --coverage"
+}
+```
+
+### 2. Integration Tests
+
+Integration tests verify real boundaries without requiring real GroupMe credentials or a full OpenClaw deployment.
+
+Planned structure:
+
+```text
+tests/
+  integration/
+    package-contract.test.ts
+    install-smoke.test.ts
+    plugin-contract.test.ts
+    webhook-flow.test.ts
+    groupme-http-boundary.test.ts
+    onboarding-http-boundary.test.ts
+```
+
+Recommended script:
+
+```json
+{
+  "test:integration": "vitest run tests/integration"
+}
+```
+
+Integration tests should run in normal CI on Node 22 and 24.
+
+#### Package Contract Test
+
+Purpose: prove the package artifact contains what OpenClaw and ClawHub need.
+
+Implementation:
+
+- Run `npm run build`.
+- Run `npm pack --json` from the test or CI step.
+- Inspect the generated tarball contents.
+- Assert the package includes:
+  - `package/openclaw.plugin.json`
+  - `package/dist/index.js`
+  - `package/dist/setup-entry.js`
+  - `package/index.ts`
+  - sidecar API files listed in `package.json#files`
+  - expected source files under `package/src/`
+- Read packaged `package/package.json`.
+- Assert:
+  - `openclaw.extensions` points to an existing packaged file.
+  - `openclaw.setupEntry` points to an existing packaged file.
+  - `openclaw.compat.pluginApi` is compatible with `>=2026.6.1`.
+  - `peerDependencies.openclaw` is compatible with `>=2026.6.1`.
+  - `engines.node` stays aligned with CI.
+
+Notes:
+
+- This can be implemented with Node's `child_process`, `fs`, and `tar` package if added as a dev dependency, or by shelling out to `npm pack --dry-run --json`.
+- Prefer a test that inspects the real tarball, not only local files.
+
+#### Install Smoke Test
+
+Purpose: prove a consumer can install and load the packed plugin.
+
+Implementation:
+
+- Create a temporary directory under the OS temp folder.
+- Run `npm init -y`.
+- Install the packed tarball plus `openclaw@2026.6.1`.
+- Run a small Node script from that temp project.
+- Assert imports work from the installed package:
+  - `openclaw-groupme/dist/index.js`
+  - `openclaw-groupme/dist/setup-entry.js`
+  - any sidecar entrypoints that OpenClaw expects to load directly
+- Assert plugin metadata is present:
+  - channel id is `groupme`
+  - setup entry exists
+  - secret contract exposes `botId`, `accessToken`, and `callbackToken`
+
+Notes:
+
+- This does not require Docker.
+- This does not require a full OpenClaw deployment.
+- This catches package layout regressions that normal unit tests miss.
+
+#### Plugin Contract Test
+
+Purpose: prove the plugin conforms to OpenClaw's channel plugin contract.
+
+Implementation:
+
+- Import the built plugin entrypoint.
+- If OpenClaw exposes a plugin loader or inspection API, use that API.
+- Otherwise, use a lightweight contract harness that asserts:
+  - plugin registration succeeds
+  - channel id is `groupme`
+  - config schema accepts modern config
+  - config schema accepts OpenClaw `SecretInput` references
+  - setup adapter exists
+  - onboarding adapter exists
+  - gateway start registers a webhook route
+  - status snapshot builder handles unresolved secret references safely
+
+Follow-up research:
+
+- Inspect OpenClaw `v2026.6.1` for a public plugin loader, plugin inspector, or SDK test helper.
+- If available, prefer OpenClaw's loader over a custom local harness.
+
+#### Webhook Flow Integration Test
+
+Purpose: exercise the inbound webhook path using real HTTP requests and a fake runtime.
+
+Implementation:
+
+- Start a local `node:http` server inside the test.
+- Mount `createGroupMeWebhookHandler()` at a configured path.
+- Build a fake `PluginRuntime` with the minimal methods needed by inbound processing.
+- Send real `fetch()` requests to the local server.
+- Assert:
+  - non-POST requests return `405`.
+  - missing or invalid callback token is rejected.
+  - valid GroupMe callback payload returns `200`.
+  - accepted webhook schedules inbound processing.
+  - bot/system/empty messages are ignored.
+  - replayed payloads are deduplicated.
+  - group binding rejects the wrong `group_id`.
+  - per-IP and per-sender rate limits are enforced.
+
+Notes:
+
+- This test should use real `Request`/`Response` and HTTP serialization.
+- It should not call GroupMe.
+- It should not require Docker.
+
+#### GroupMe HTTP Boundary Test
+
+Purpose: test outbound GroupMe API behavior against HTTP-shaped endpoints instead of only function mocks.
+
+Implementation options:
+
+- Add internal base URL overrides:
+
+```ts
+const GROUPME_API_BASE =
+  process.env.GROUPME_API_BASE_URL ?? "https://api.groupme.com/v3";
+
+const GROUPME_IMAGE_SERVICE =
+  process.env.GROUPME_IMAGE_SERVICE_URL ?? "https://image.groupme.com";
+```
+
+- Start local fake HTTP servers for:
+  - Bot API `/bots/post`
+  - Image Service `/pictures`
+  - remote media download URL
+- Call real send helpers.
+- Assert:
+  - outbound text sends `POST /bots/post`
+  - body contains `bot_id` and `text`
+  - media flow downloads remote media, uploads it, then posts with `picture_url`
+  - error responses are surfaced clearly
+  - oversized or invalid media is rejected before posting
+
+Notes:
+
+- Existing `fetchFn` injection in `send.ts` already supports a lot of this.
+- A local server catches URL/method/body mistakes better than a bare `vi.fn()`.
+
+#### Onboarding HTTP Boundary Test
+
+Purpose: verify onboarding against fake GroupMe API HTTP endpoints.
+
+Implementation:
+
+- Add testable base URL injection for `src/groupme-api.ts`.
+- Start a local fake GroupMe API server.
+- Serve:
+  - `/groups`
+  - `/bots`
+- Run onboarding with a fake prompter.
+- Assert:
+  - groups request includes the access token
+  - selected group is used
+  - bot creation request includes `name`, `group_id`, and callback URL
+  - callback URL includes public domain, webhook path, and `k` token
+  - saved config keeps `webhookPath` and `callbackToken` separate
+
+## 3. Live Smoke Tests
+
+Live smoke tests call the real GroupMe API. They should be optional, manually triggered, and skipped when credentials are missing.
+
+Planned structure:
+
+```text
+tests/
+  live/
+    groupme-live.test.ts
+```
+
+Recommended scripts:
+
+```json
+{
+  "test:live": "vitest run tests/live"
+}
+```
+
+Required secrets:
+
+- `GROUPME_LIVE_ACCESS_TOKEN`
+- `GROUPME_LIVE_BOT_ID`
+- `GROUPME_LIVE_GROUP_ID`
+
+The live test should skip unless all required secrets are set.
+
+Example behavior:
+
+- Send a short text message to a private test GroupMe group.
+- Include a unique run id in the message.
+- Assert GroupMe returns success.
+- Do not run on pull requests.
+- Do not run on contributor forks.
+
+Optional later behavior:
+
+- Create a temporary bot in a test group.
+- Register a callback URL.
+- Verify bot creation and deletion if GroupMe supports cleanup cleanly.
+- Exercise image upload with a tiny fixture image.
+
+Manual GitHub Actions workflow:
+
+```yaml
+name: Live Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  groupme-live:
+    runs-on: ubuntu-latest
+    if: github.repository == 'oddrationale/openclaw-groupme'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:live
+        env:
+          GROUPME_LIVE_ACCESS_TOKEN: ${{ secrets.GROUPME_LIVE_ACCESS_TOKEN }}
+          GROUPME_LIVE_BOT_ID: ${{ secrets.GROUPME_LIVE_BOT_ID }}
+          GROUPME_LIVE_GROUP_ID: ${{ secrets.GROUPME_LIVE_GROUP_ID }}
+```
+
+## CI Plan
+
+Normal pull request CI:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:unit
+npm run test:integration
+npm run build
+npm run knip
+npm run test:coverage
+npm pack --dry-run
+```
+
+Manual live smoke CI:
+
+```bash
+npm run build
+npm run test:live
+```
+
+Recommended script shape:
+
+```json
+{
+  "check": "npm run lint && npm run typecheck && npm run test:unit && npm run test:integration && npm run build && npm run knip",
+  "test": "npm run test:unit",
+  "test:unit": "vitest run tests/unit",
+  "test:integration": "vitest run tests/integration",
+  "test:live": "vitest run tests/live",
+  "test:coverage": "vitest run tests/unit tests/integration --coverage"
+}
+```
+
+## Docker Guidance
+
+Docker is not required for the planned Unit Tests or Integration Tests.
+
+Use plain Node/Vitest plus local HTTP servers for:
+
+- webhook request/response tests
+- fake GroupMe API tests
+- outbound HTTP boundary tests
+- package installation smoke tests
+
+Docker may become useful only if the project later needs:
+
+- a full OpenClaw deployment smoke test
+- a reverse proxy or public tunnel
+- a persistent database or queue
+- a multi-service topology
+
+Even for Live Smoke Tests, Docker does not solve the hardest problem: GroupMe webhooks require a public callback URL. Start with outbound-only live smoke tests, then consider webhook smoke tests only if the value outweighs the tunnel/deployment complexity.
+
+## Implementation Phases
+
+### Phase 1: Test Organization
+
+- Create `tests/unit/`.
+- Move current tests into `tests/unit/`.
+- Update imports.
+- Add `test:unit`, `test:integration`, and `test:live` scripts.
+- Keep `npm test` mapped to unit tests.
+- Update CI to run `test:unit`.
+
+Acceptance criteria:
+
+- Current test count is preserved.
+- `npm run check` passes.
+- Coverage stays at or above current thresholds.
+
+### Phase 2: Package And Install Confidence
+
+- Add `tests/integration/package-contract.test.ts`.
+- Add `tests/integration/install-smoke.test.ts`.
+- Ensure integration tests can pack and install the package in a temp directory.
+- Add integration tests to normal CI.
+
+Acceptance criteria:
+
+- CI proves the packed tarball contains the runtime files OpenClaw will load.
+- CI proves the packed tarball can be installed in a clean project.
+
+### Phase 3: OpenClaw Plugin Contract
+
+- Research OpenClaw `v2026.6.1` for a plugin loader or inspection API.
+- Add a loader-based contract test if available.
+- Otherwise add a lightweight harness that validates channel plugin shape.
+
+Acceptance criteria:
+
+- Test fails if the plugin cannot be registered or does not expose expected OpenClaw channel capabilities.
+- Secret contracts and setup entrypoints are verified.
+
+### Phase 4: HTTP Boundary Integration
+
+- Add fake GroupMe API base URL overrides where needed.
+- Add local HTTP server helpers under `tests/integration/helpers/`.
+- Add outbound Bot API tests.
+- Add image upload/media flow tests.
+- Add onboarding fake GroupMe API tests.
+
+Acceptance criteria:
+
+- Tests verify HTTP method, path, query, headers, and JSON payload shape.
+- Tests do not require real GroupMe credentials.
+
+### Phase 5: Webhook End-To-End Local Flow
+
+- Add local webhook server integration tests.
+- Use realistic GroupMe callback fixtures.
+- Use a fake OpenClaw runtime that records session/reply behavior.
+
+Acceptance criteria:
+
+- A valid callback moves through the full local webhook pipeline.
+- Security failures are covered at the HTTP boundary.
+- Runtime calls are asserted without contacting GroupMe.
+
+### Phase 6: Live Smoke Test
+
+- Add `tests/live/groupme-live.test.ts`.
+- Add manual `Live Smoke` GitHub Actions workflow.
+- Store secrets in GitHub Actions environment/repository secrets.
+- Start with outbound text send only.
+
+Acceptance criteria:
+
+- Live smoke test is skipped without secrets.
+- Manual workflow can post to a private test GroupMe group.
+- No live smoke test runs automatically on pull requests.
+
+## Open Questions
+
+- Does OpenClaw `v2026.6.1` expose a plugin loader or inspector suitable for tests?
+- Should HTTP base URL overrides be environment variables, explicit function parameters, or internal test-only helpers?
+- Should integration tests run on both Node 22 and 24, or only Node 24 after unit tests cover both?
+- Should live smoke tests use a dedicated GroupMe bot and group owned by the project maintainer?
+- Should the live smoke workflow require a protected GitHub environment approval?

--- a/docs/2026-06-06-integration-testing-plan.md
+++ b/docs/2026-06-06-integration-testing-plan.md
@@ -12,6 +12,25 @@ Build confidence that `openclaw-groupme` installs, loads, and behaves correctly 
 
 The intent is to keep normal CI deterministic and credential-free while still providing an optional path to verify real GroupMe behavior before releases.
 
+## Implementation Status
+
+Implemented in this branch:
+
+- Unit tests have been moved to `tests/unit/`, and `npm test` now runs the unit suite.
+- Integration tests live under `tests/integration/` and run in normal `npm run check`.
+- Package contract tests verify the packed npm artifact includes the compiled OpenClaw runtime entrypoints, source sidecars, `openclaw.plugin.json`, and manifest compatibility fields.
+- Install smoke tests pack the plugin, install it into a clean temporary project with OpenClaw, and import the installed runtime/setup/channel/secret sidecars.
+- Plugin contract tests import the built entrypoints and assert the GroupMe channel capability, setup adapter, secret contract, and config schema runtime contract.
+- GroupMe HTTP boundary tests use local HTTP servers to verify request method, path, query, headers, and JSON/body shape for group listing, bot creation, outbound bot posts, and image uploads.
+- Live smoke tests live under `tests/live/`, skip without credentials, and post to GroupMe only when explicitly run with the live secrets.
+- A manual-only `Live Smoke` GitHub Actions workflow runs `npm run test:live` with the `groupme-live-smoke` environment and a concurrency guard.
+
+Still good candidates for later expansion:
+
+- A deeper webhook-flow integration test that runs the full inbound path with a richer fake OpenClaw runtime instead of the existing focused unit-level webhook server tests.
+- A full onboarding wizard integration test backed by local fake HTTP endpoints rather than the current API-boundary tests and mocked unit onboarding tests.
+- OpenClaw CLI `plugins install` / `plugins inspect --json --runtime groupme` smoke tests once a stable isolated OpenClaw profile setup is documented for CI.
+
 ## Test Categories
 
 ### 1. Unit Tests
@@ -445,10 +464,130 @@ Acceptance criteria:
 - Manual workflow can post to a private test GroupMe group.
 - No live smoke test runs automatically on pull requests.
 
-## Open Questions
+## Resolved Decisions
 
-- Does OpenClaw `v2026.6.1` expose a plugin loader or inspector suitable for tests?
-- Should HTTP base URL overrides be environment variables, explicit function parameters, or internal test-only helpers?
-- Should integration tests run on both Node 22 and 24, or only Node 24 after unit tests cover both?
-- Should live smoke tests use a dedicated GroupMe bot and group owned by the project maintainer?
-- Should the live smoke workflow require a protected GitHub environment approval?
+### OpenClaw Loader Or Inspector
+
+Decision: use the OpenClaw CLI plugin commands for package-level integration confidence, not OpenClaw's internal loader modules.
+
+OpenClaw `v2026.6.1` does not expose a public package subpath for the runtime plugin loader. A direct import such as `openclaw/plugins/loader` is blocked by package exports. The package does expose the plugin SDK surfaces, and the CLI exposes plugin inspection commands:
+
+```bash
+openclaw plugins inspect --json --runtime <id>
+openclaw plugins install <path-or-spec-or-plugin>
+openclaw plugins validate --root <path> --entry <path>
+```
+
+Use those commands for install/load confidence:
+
+- `npm pack` this package.
+- Install the tarball into an isolated OpenClaw profile or temporary project.
+- Run `openclaw plugins inspect --json --runtime groupme`.
+- Assert the inspected plugin has the expected id, metadata, setup entry, channel capability, and secret contract.
+
+Avoid importing OpenClaw internal loader files from `dist/plugins/loader.js`. They are useful implementation evidence, but not a stable contract for this plugin's CI.
+
+### HTTP Base URL Overrides
+
+Decision: prefer explicit dependency injection for HTTP tests; use environment variables only at process-boundary smoke layers.
+
+For module-level integration tests, add optional parameters to low-level API helpers instead of process-global test hooks:
+
+```ts
+type GroupMeApiOptions = {
+  fetchFn?: FetchLike;
+  apiBaseUrl?: string;
+  imageBaseUrl?: string;
+};
+```
+
+Apply this pattern to:
+
+- `fetchGroups()`
+- `createBot()`
+- outbound send helpers where base URLs are currently constants
+
+Rationale:
+
+- Explicit parameters keep tests isolated and parallel-safe.
+- Tests can point one call at a local fake GroupMe server without mutating global process state.
+- Production config stays clean; users do not see test-only base URL options.
+- Existing `fetchFn` injection in `send.ts` already follows this direction.
+
+Use environment variables only when the test is intentionally crossing a process boundary, such as an install smoke script or live smoke workflow:
+
+```bash
+GROUPME_LIVE_ACCESS_TOKEN=...
+GROUPME_LIVE_BOT_ID=...
+GROUPME_LIVE_GROUP_ID=...
+```
+
+Avoid public runtime config fields such as `groupmeApiBaseUrl` unless a real user-facing need appears.
+
+### Node Matrix Scope
+
+Decision: keep unit tests on both supported CI Node versions; start integration tests on both Node 22 and 24 unless runtime becomes too slow.
+
+The package declares `engines.node: ">=22.19.0"`, so CI should prove at least one meaningful install/load path on Node 22. A good default is:
+
+- Node 22:
+  - unit tests
+  - package contract test
+  - install smoke test
+  - OpenClaw CLI inspect smoke test
+- Node 24:
+  - unit tests
+  - full integration suite
+  - coverage
+  - package contract test
+  - install smoke test
+  - OpenClaw CLI inspect smoke test
+
+If the integration suite remains fast, run all normal integration tests on both Node 22 and 24. If it becomes slow, keep the broader HTTP-boundary tests on Node 24 and retain the package/install/plugin-contract smoke tests on Node 22.
+
+Live smoke tests should run only on Node 24 unless a Node-version-specific live issue appears.
+
+### Live Smoke GroupMe Resources
+
+Decision: use a dedicated private GroupMe bot and group for live smoke tests.
+
+Do not use a personal or shared real conversation. Create a private test group owned by the maintainer and a dedicated bot used only by CI/live smoke. Store only that bot's credentials in GitHub secrets.
+
+Recommended resources:
+
+- `GROUPME_LIVE_ACCESS_TOKEN`
+- `GROUPME_LIVE_BOT_ID`
+- `GROUPME_LIVE_GROUP_ID`
+
+Recommended operational rules:
+
+- The test group name should clearly identify it as automation-owned.
+- Live smoke messages should include a unique run id and repository/branch context.
+- Live smoke tests should avoid deleting or mutating unrelated GroupMe state.
+- If bot creation/deletion smoke tests are added later, keep them separate from the basic outbound-send smoke test.
+- Rotate the GroupMe access token if it is ever exposed in logs or copied outside GitHub secrets.
+
+### Live Smoke Workflow Protection
+
+Decision: use a protected GitHub Environment for live smoke tests.
+
+The workflow should be manual-only with `workflow_dispatch`, and the secrets should live in a protected environment such as `groupme-live-smoke`.
+
+Recommended workflow safeguards:
+
+- Require maintainer approval before the environment is used.
+- Restrict environment secrets to the live smoke workflow.
+- Add `if: github.repository == 'oddrationale/openclaw-groupme'`.
+- Do not run live smoke on pull requests.
+- Add a concurrency group so only one live smoke run can post at a time.
+
+Example:
+
+```yaml
+environment: groupme-live-smoke
+concurrency:
+  group: groupme-live-smoke
+  cancel-in-progress: false
+```
+
+This keeps normal PR CI credential-free while still allowing a real API check before releases.

--- a/docs/2026-06-06-openclaw-channel-confidence-plan.md
+++ b/docs/2026-06-06-openclaw-channel-confidence-plan.md
@@ -1,0 +1,508 @@
+# OpenClaw Channel Confidence Plan
+
+Date: 2026-06-06
+
+## Goal
+
+Increase confidence that an installed `openclaw-groupme` package works as an OpenClaw channel plugin, not just as a collection of GroupMe API helper functions.
+
+This plan focuses on the next three confidence layers:
+
+1. OpenClaw CLI installed-channel smoke tests
+2. Live plugin outbound smoke tests
+3. Future live inbound callback smoke test ideas
+
+The reference OpenClaw checkout at `~/Local/openclaw` was checked against `v2026.6.1` (`2e08f0f422`). The current plugin branch already has useful unit, integration, package, install, webhook, onboarding, and raw GroupMe API live tests. The remaining gap is proving the OpenClaw-facing channel surface behaves as a user would expect after installation.
+
+## Implementation Status
+
+Implemented in this branch:
+
+- The deterministic OpenClaw CLI smoke now installs the packed plugin, verifies channel catalog discovery, configures the channel with `openclaw channels add`, checks channel status, and dry-runs `openclaw message send --channel groupme`.
+- The low-level live credential probe has been renamed to `tests/live/groupme-api-live.test.ts`.
+- A new manual live plugin outbound smoke has been added at `tests/live/groupme-plugin-outbound-live.test.ts`. It installs the packed plugin into an isolated OpenClaw home, configures live credentials as env-backed SecretRefs, and sends through the public `openclaw message send --channel groupme` path.
+- The manual `Live Smoke` workflow now runs the API live smoke first, then the plugin outbound live smoke.
+
+Local verification skips the live tests unless `GROUPME_LIVE_ACCESS_TOKEN`, `GROUPME_LIVE_BOT_ID`, and `GROUPME_LIVE_GROUP_ID` are exported. The actual live GroupMe post is expected to run through the manual GitHub Actions workflow because the credentials are stored as repository secrets.
+
+## Current Findings
+
+OpenClaw v2026.6.1 can install and inspect this plugin from the packed tarball:
+
+```bash
+openclaw plugins install ./openclaw-groupme-<version>.tgz --force
+openclaw plugins inspect groupme --json --runtime
+```
+
+After installation, OpenClaw reports `groupme` as a loaded channel capability, and `openclaw channels list --all --json` includes `groupme` with `installed: true`.
+
+After installation, this also works non-interactively:
+
+```bash
+openclaw channels add --channel groupme --token fake-bot --account default --name Probe
+openclaw channels list --json
+openclaw channels status --channel groupme --json
+```
+
+`openclaw message send --channel groupme ...` reports `Unknown channel: groupme` when the plugin is installed but no `channels.groupme` config exists yet. After `openclaw channels add --channel groupme ...`, `openclaw message send --channel groupme --target <group-id> --message <text> --dry-run --json` succeeds. The message CLI path should therefore be included in the installed-channel smoke after channel setup, not immediately after plugin install.
+
+## 1. OpenClaw CLI Installed-Channel Smoke Tests
+
+Purpose: prove the packed plugin can be installed into a clean OpenClaw home, discovered as a channel, configured through OpenClaw's channel setup command, and inspected without a running gateway or real GroupMe credentials.
+
+This belongs in normal CI because it is deterministic, credential-free, and does not call GroupMe.
+
+### Test Location
+
+Extend the existing test:
+
+```text
+tests/integration/openclaw-cli-smoke.test.ts
+```
+
+Keep it serialized with the rest of the integration suite because packing/building mutates `dist/` and produces package artifacts.
+
+### Environment
+
+Each test should create an isolated temporary OpenClaw home:
+
+```ts
+{
+  HOME: tempHome,
+  USERPROFILE: tempHome,
+  CODEX_HOME: tempHome,
+  NO_COLOR: "1",
+  OPENCLAW_DISABLE_BONJOUR: "1",
+  VITEST: "",
+  VITEST_WORKER_ID: ""
+}
+```
+
+Use the repo-installed OpenClaw CLI from:
+
+```text
+node_modules/openclaw/openclaw.mjs
+```
+
+That keeps the test pinned to the `openclaw` dev dependency version.
+
+### Assertions
+
+Install and inspect:
+
+- Run `npm run build`.
+- Pack the plugin tarball with scripts disabled after the explicit build.
+- Run `openclaw plugins install <tarball> --force`.
+- Run `openclaw plugins inspect groupme --json --runtime`.
+- Assert:
+  - plugin id is `groupme`
+  - package name is `openclaw-groupme`
+  - status is `loaded`
+  - channel ids include only `groupme`
+  - capability list includes `{ kind: "channel", ids: ["groupme"] }`
+  - config schema is present
+  - runtime diagnostics contain no errors
+  - dependency status reports required dependencies installed
+
+Channel catalog discovery:
+
+- Run `openclaw channels list --all --json`.
+- Assert `chat.groupme.installed === true`.
+- Assert `chat.groupme.origin === "available"`.
+- This catches regressions where plugin inspection works but the channel catalog cannot see the installed external channel.
+
+Channel setup command:
+
+- Run `openclaw channels add --channel groupme --token fake-bot --account default --name Probe`.
+- Run `openclaw config get channels.groupme --json`.
+- Assert:
+  - `enabled === true`
+  - `name === "Probe"`
+  - `botId === "fake-bot"`
+- Run `openclaw channels list --json`.
+- Assert:
+  - `chat.groupme.installed === true`
+  - `chat.groupme.origin === "configured"`
+  - `chat.groupme.accounts` includes `default`
+
+Config-only status:
+
+- Run `openclaw channels status --channel groupme --json`.
+- Do not require a gateway to be running.
+- Assert:
+  - command exits successfully
+  - `configOnly === true`
+  - `configuredChannels` includes `groupme`
+- This proves the status command accepts the dynamically installed channel id and can at least report local config.
+
+Message send dry run:
+
+- Run `openclaw message send --channel groupme --target 123 --message probe --dry-run --json` after `channels add`.
+- Assert:
+  - command exits successfully
+  - `channel === "groupme"`
+  - `action === "send"`
+  - `dryRun === true`
+  - `payload.to === "123"`
+- This proves the public message CLI can select the dynamically installed GroupMe channel once it is configured.
+
+Installed but unconfigured behavior:
+
+- Optionally assert that `message send` before `channels add` fails with `Unknown channel: groupme`.
+- Treat that as expected behavior, not an upstream bug: the message CLI preloads configured channels for message actions.
+
+### Acceptance Criteria
+
+This layer is complete when a clean CI run proves:
+
+- the npm package artifact installs into OpenClaw
+- OpenClaw runtime inspection loads the plugin
+- OpenClaw channel catalog sees `groupme`
+- OpenClaw channel setup writes a usable `channels.groupme` config section
+- OpenClaw channel status recognizes the configured external channel
+- OpenClaw message send dry-run recognizes the configured external channel
+
+No Docker is needed for this layer.
+
+## 2. Live Plugin Outbound Smoke Tests
+
+Purpose: prove the GroupMe plugin's OpenClaw channel outbound surface can send a real message to the live configured GroupMe group.
+
+This is different from the current live test. The current live test calls GroupMe's REST API directly, so it mostly proves the secrets and GroupMe API are working. The proposed live plugin outbound smoke should route through the plugin's channel object and runtime-facing outbound contract.
+
+This should stay manual-only because it uses real GroupMe credentials and posts to a real group.
+
+### Test Location
+
+Use a live test that is separate from the raw API credential probe:
+
+```text
+tests/live/groupme-plugin-outbound-live.test.ts
+```
+
+The low-level credential probe is named so its scope is explicit:
+
+```text
+tests/live/groupme-api-live.test.ts
+tests/live/groupme-plugin-outbound-live.test.ts
+```
+
+`groupme-api-live.test.ts` should only prove the repository secrets can read the configured GroupMe group and post through the configured bot. `groupme-plugin-outbound-live.test.ts` should prove the installed OpenClaw channel path can send through the plugin.
+
+### Required Secrets
+
+Use the existing secrets:
+
+```text
+GROUPME_LIVE_ACCESS_TOKEN
+GROUPME_LIVE_BOT_ID
+GROUPME_LIVE_GROUP_ID
+```
+
+No personal developer token is required in normal CI. The GitHub repository secrets are enough for the manual workflow.
+
+Local contributors can opt in by exporting the same variables. Tests should skip cleanly when any required secret is missing.
+
+### Harness
+
+Use the public OpenClaw CLI from an isolated installed-plugin home, with credentials configured as env-backed SecretRefs:
+
+```bash
+openclaw plugins install ./openclaw-groupme-<version>.tgz --force
+openclaw channels add --channel groupme --token placeholder --account default --name "Live Smoke"
+openclaw config set channels.groupme.botId --ref-source env --ref-provider default --ref-id GROUPME_LIVE_BOT_ID
+openclaw config set channels.groupme.accessToken --ref-source env --ref-provider default --ref-id GROUPME_LIVE_ACCESS_TOKEN
+openclaw config set channels.groupme.groupId "$GROUPME_LIVE_GROUP_ID"
+openclaw message send --channel groupme --target "$GROUPME_LIVE_GROUP_ID" --message "openclaw-groupme plugin outbound live <run-id>" --json
+```
+
+This is the strongest outbound smoke that does not require a running gateway because it exercises:
+
+- package install into OpenClaw
+- channel setup
+- config loading and secret resolution
+- message CLI channel selection
+- OpenClaw message action runner
+- plugin outbound adapter
+- GroupMe Bot API post
+
+The implementation should generate or patch the isolated OpenClaw config with SecretRef objects for `botId` and `accessToken` instead of writing plaintext credentials to disk. `groupId` is not a secret and can be written directly. If `channels add --token env:...` does not produce the exact SecretRef object needed, write the isolated config file through the test harness and then invoke `openclaw message send`.
+
+### Non-Live Debug Harness
+
+Do not add a required live `deliverOutboundPayloads` test. The public CLI live smoke is the required outbound confidence layer because it exercises the user-facing path and avoids depending on OpenClaw's compatibility/deprecated outbound substrate.
+
+If debugging requires a narrower harness, use it as a deterministic integration test against a fake GroupMe HTTP server, not as an additional live smoke. Possible debug imports:
+
+```ts
+import { deliverOutboundPayloads } from "openclaw/plugin-sdk/outbound-runtime";
+import {
+  createPluginRuntimeMock,
+  createTestRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { groupmePlugin } from "../../dist/channel-plugin-api.js";
+import { setGroupMeRuntime } from "../../dist/runtime-setter-api.js";
+```
+
+The exact import paths should be validated against the installed `openclaw@2026.6.1` exports before implementation. If a helper is not exported from the published package, use the narrower available exported subpath or keep the harness local.
+
+The deterministic debug test should:
+
+- Build the plugin before running live tests.
+- Import `dist/channel-plugin-api.js`.
+- Import `dist/runtime-setter-api.js`.
+- Create a minimal `PluginRuntime` mock with:
+  - `channel.text.chunkMarkdownText`
+  - `channel.media.fetchRemoteMedia` if testing media later
+  - logging methods, if required by OpenClaw helpers
+- Call `setGroupMeRuntime(runtimeMock)`.
+- Register `groupmePlugin` in an active OpenClaw plugin registry if using `deliverOutboundPayloads`.
+- Build a config object:
+
+```ts
+{
+  channels: {
+    groupme: {
+      enabled: true,
+      botId: process.env.GROUPME_LIVE_BOT_ID,
+      accessToken: process.env.GROUPME_LIVE_ACCESS_TOKEN,
+      groupId: process.env.GROUPME_LIVE_GROUP_ID
+    }
+  }
+}
+```
+
+- Send a unique text payload through the plugin outbound path:
+
+```ts
+await deliverOutboundPayloads({
+  cfg,
+  channel: "groupme",
+  to: process.env.GROUPME_LIVE_GROUP_ID,
+  payloads: [{ text: `openclaw-groupme plugin outbound live ${runId}` }],
+  skipQueue: true
+});
+```
+
+- Assert:
+  - the result reports `channel: "groupme"`
+  - a `messageId` is returned
+  - no runtime/plugin contract error is thrown
+  - the fake GroupMe Bot API receives the expected request
+
+### Direct Adapter Fallback
+
+If `deliverOutboundPayloads` cannot be cleanly used by an external plugin test, call the plugin's exported channel outbound adapter directly in deterministic integration tests:
+
+```ts
+await groupmePlugin.outbound.sendText({
+  cfg,
+  to: process.env.GROUPME_LIVE_GROUP_ID,
+  text: `openclaw-groupme plugin outbound live ${runId}`,
+  accountId: "default"
+});
+```
+
+This is still better than the raw API test because it exercises:
+
+- built sidecar import
+- runtime singleton initialization
+- account resolution
+- channel target normalization
+- channel outbound adapter
+- `sendGroupMeText`
+- GroupMe Bot API post
+
+The CLI harness is strongest because it exercises the same entrypoint a user would run. The outbound substrate harness is useful when less process overhead is needed but OpenClaw-shaped plugin dispatch still matters. The direct adapter harness should be reserved for debugging or as a narrow fallback.
+
+### Media Live Smoke
+
+Do not include image upload in the initial plugin outbound live smoke. Keep the first live plugin outbound test text-only so failures are easy to diagnose.
+
+Once the text path is stable, add a separate optional live media test:
+
+```text
+tests/live/groupme-plugin-media-live.test.ts
+```
+
+That test should verify:
+
+- remote image download through the plugin media policy
+- GroupMe image service upload
+- Bot API post with `picture_url`
+
+It should have its own script, for example:
+
+```json
+{
+  "test:live:plugin-media": "vitest run tests/live/groupme-plugin-media-live.test.ts"
+}
+```
+
+The live workflow can run the media smoke after the text smoke, or keep it behind a separate manual input if the media path proves noisier.
+
+### Manual Workflow
+
+Keep `.github/workflows/live-smoke.yml` manual-only:
+
+```yaml
+on:
+  workflow_dispatch:
+```
+
+Add a separate job or separate test script if helpful:
+
+```json
+{
+  "test:live": "vitest run tests/live",
+  "test:live:api": "vitest run tests/live/groupme-api-live.test.ts",
+  "test:live:plugin-outbound": "vitest run tests/live/groupme-plugin-outbound-live.test.ts"
+}
+```
+
+Recommended workflow order:
+
+1. `npm ci`
+2. `npm run build`
+3. `npm run test:live:api`
+4. `npm run test:live:plugin-outbound`
+5. Optional later: `npm run test:live:plugin-media`
+
+The API probe should run first because it fails with clearer credential diagnostics.
+
+### Acceptance Criteria
+
+This layer is complete when the manual live workflow proves:
+
+- GitHub secrets can access the target GroupMe group
+- the packed plugin installs under `openclaw@2026.6.1`
+- OpenClaw channel setup configures the live GroupMe channel
+- live credentials are supplied through env-backed SecretRefs, not plaintext config values
+- the public `openclaw message send --channel groupme` path posts to GroupMe
+- failure output clearly distinguishes credential failure, plugin contract failure, and GroupMe API failure
+
+No Docker is needed for this layer.
+
+## 3. Future Live Inbound Callback Smoke Ideas
+
+Purpose: prove a real GroupMe message can enter OpenClaw through the plugin webhook path and trigger OpenClaw-style inbound handling.
+
+This is the first layer that may need public network reachability. It is also the layer most likely to create operational noise, so it should be optional and deliberately manual.
+
+### What It Should Prove
+
+A true inbound smoke would prove:
+
+- OpenClaw starts the GroupMe channel account lifecycle
+- the plugin registers its webhook route
+- GroupMe can reach that route over the public internet
+- callback token validation succeeds
+- replay/rate-limit/group-binding checks allow the expected live callback
+- inbound processing records a session or dispatches a reply through the OpenClaw runtime
+- the channel can optionally reply back to GroupMe through the plugin outbound path
+
+### Option A: Local Gateway With Tunnel
+
+Run OpenClaw locally in CI or on a developer machine and expose only the webhook route through a tunnel.
+
+Possible tunnel providers:
+
+- Cloudflare Tunnel
+- Tailscale Funnel
+- ngrok
+
+Implementation outline:
+
+- Start an isolated OpenClaw home.
+- Install the packed plugin.
+- Configure `channels.groupme` with:
+  - live `botId`
+  - live `accessToken`
+  - live `groupId`
+  - generated callback token
+  - `publicDomain` pointing at the tunnel URL
+  - `webhookPath` with a unique run id
+- Start `openclaw gateway run` in the background.
+- Start the tunnel.
+- Register or update the GroupMe bot callback URL.
+- Send a controlled live message into the GroupMe group.
+- Wait for a runtime-observable signal:
+  - channel activity timestamp
+  - session record
+  - webhook HTTP log
+  - reply delivery
+- Restore the previous bot callback URL at the end.
+
+Tradeoffs:
+
+- Strong confidence.
+- More moving pieces.
+- Requires a tunnel token or a preconfigured tunnel.
+- Must be careful to restore GroupMe bot callback state.
+
+### Option B: Reusable Staging OpenClaw Gateway
+
+Keep a small staging OpenClaw instance running with this plugin installed.
+
+Implementation outline:
+
+- Deploy OpenClaw with the current plugin tarball or branch artifact.
+- Configure the live GroupMe bot callback to the staging gateway.
+- Trigger the smoke by sending a unique message to the test group.
+- Query staging logs, health, status, or session records to verify receipt.
+- Optionally assert a bot reply appears in GroupMe.
+
+Tradeoffs:
+
+- Strongest user-like confidence.
+- Operationally heavier.
+- Requires lifecycle management for the staging instance.
+- Needs clear ownership of secrets, logs, and cleanup.
+
+### Option C: Synthetic Public Webhook Receiver
+
+Expose only the plugin webhook handler in a tiny test server instead of starting the full OpenClaw gateway.
+
+Implementation outline:
+
+- Start a minimal Node HTTP server.
+- Mount `createGroupMeWebhookHandler()` with a fake `PluginRuntime`.
+- Expose the server through a tunnel.
+- Temporarily point the GroupMe bot callback URL at the tunnel URL.
+- Send a real GroupMe message.
+- Assert the fake runtime observed the inbound envelope.
+
+Tradeoffs:
+
+- Lighter than full OpenClaw.
+- Tests real GroupMe callback delivery and the plugin inbound pipeline.
+- Does not prove full OpenClaw gateway lifecycle or session persistence.
+- A good intermediate step before Option A or B.
+
+### Safety Requirements
+
+Any live inbound test should:
+
+- be manual-only
+- use a dedicated test GroupMe group
+- generate a unique callback path and callback token per run
+- restore the previous bot callback URL
+- redact tokens from logs
+- time out quickly
+- avoid replying to arbitrary user messages unless the run id matches
+- use concurrency controls so two live inbound runs cannot fight over the same bot callback URL
+
+### Recommended Future Order
+
+1. Keep #1 in normal CI because it is deterministic and credential-free.
+2. Keep #2 in the manual live workflow because it uses real GroupMe credentials and posts to a real group.
+3. Add Option C for #3 as the first inbound live test.
+4. Move to Option A or B only after Option C proves the bot callback lifecycle is manageable.
+
+## Resolved Decisions
+
+- Rename the raw API live test to `groupme-api-live.test.ts`.
+- Configure live plugin outbound credentials through env-backed SecretRefs. Do not write plaintext `botId` or `accessToken` values to the isolated OpenClaw config.
+- Use the public `openclaw message send --channel groupme` path as the required live plugin outbound smoke. Do not add a required live `deliverOutboundPayloads` test.
+- Keep the initial live plugin outbound smoke text-only. Add image upload as a separate future live media smoke test.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "check": "npm run lint && npm run typecheck && npm test && npm run build && npm run knip",
+    "check": "npm run lint && npm run typecheck && npm run test:unit && npm run test:integration && npm run build && npm run knip",
     "commitlint": "commitlint --edit",
     "format": "biome format --write .",
     "format:check": "biome format .",
@@ -46,8 +46,11 @@
     "lint:fix": "biome check --write .",
     "prepack": "npm run build",
     "prepare": "lefthook install",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test": "npm run test:unit",
+    "test:coverage": "vitest run tests/unit tests/integration --coverage",
+    "test:integration": "vitest run tests/integration",
+    "test:live": "vitest run tests/live",
+    "test:unit": "vitest run tests/unit",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "prepack": "npm run build",
     "prepare": "lefthook install",
     "test": "npm run test:unit",
-    "test:coverage": "vitest run tests/unit tests/integration --coverage",
-    "test:integration": "vitest run tests/integration",
+    "test:coverage": "vitest run tests/unit tests/integration --coverage --no-file-parallelism",
+    "test:integration": "vitest run tests/integration --no-file-parallelism",
     "test:live": "vitest run tests/live",
     "test:unit": "vitest run tests/unit",
-    "test:watch": "vitest",
+    "test:watch": "vitest tests/unit tests/integration",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "test:coverage": "vitest run tests/unit tests/integration --coverage --no-file-parallelism",
     "test:integration": "vitest run tests/integration --no-file-parallelism",
     "test:live": "vitest run tests/live",
+    "test:live:api": "vitest run tests/live/groupme-api-live.test.ts",
+    "test:live:plugin-outbound": "vitest run tests/live/groupme-plugin-outbound-live.test.ts",
     "test:unit": "vitest run tests/unit",
     "test:watch": "vitest tests/unit tests/integration",
     "typecheck": "tsc --noEmit"

--- a/src/groupme-api.ts
+++ b/src/groupme-api.ts
@@ -2,6 +2,13 @@ import type { GroupMeApiBot, GroupMeApiGroup } from "./types.js";
 
 const GROUPME_API_BASE = "https://api.groupme.com/v3";
 
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type GroupMeApiOptions = {
+  fetchFn?: FetchLike;
+  apiBaseUrl?: string;
+};
+
 async function readApiError(response: Response): Promise<string> {
   const fallback = `GroupMe API error: ${response.status} ${response.statusText}`;
   try {
@@ -38,18 +45,23 @@ function readBotResponse(payload: unknown): GroupMeApiBot {
   return bot as GroupMeApiBot;
 }
 
-export async function fetchGroups(accessToken: string): Promise<GroupMeApiGroup[]> {
+export async function fetchGroups(
+  accessToken: string,
+  options: GroupMeApiOptions = {},
+): Promise<GroupMeApiGroup[]> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const apiBaseUrl = options.apiBaseUrl ?? GROUPME_API_BASE;
   const groups: GroupMeApiGroup[] = [];
   let page = 1;
 
   while (true) {
-    const url = new URL(`${GROUPME_API_BASE}/groups`);
+    const url = new URL(`${apiBaseUrl}/groups`);
     url.searchParams.set("token", accessToken);
     url.searchParams.set("per_page", "100");
     url.searchParams.set("omit", "memberships");
     url.searchParams.set("page", String(page));
 
-    const response = await fetch(url);
+    const response = await fetchFn(url);
     if (!response.ok) {
       throw new Error(await readApiError(response));
     }
@@ -72,11 +84,15 @@ export async function createBot(params: {
   name: string;
   groupId: string;
   callbackUrl: string;
+  fetchFn?: FetchLike;
+  apiBaseUrl?: string;
 }): Promise<GroupMeApiBot> {
-  const url = new URL(`${GROUPME_API_BASE}/bots`);
+  const fetchFn = params.fetchFn ?? fetch;
+  const apiBaseUrl = params.apiBaseUrl ?? GROUPME_API_BASE;
+  const url = new URL(`${apiBaseUrl}/bots`);
   url.searchParams.set("token", params.accessToken);
 
-  const response = await fetch(url, {
+  const response = await fetchFn(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -6,6 +6,11 @@ import { hasSecretInput, resolveGroupMeAccount } from "./accounts.js";
 import { createBot, fetchGroups } from "./groupme-api.js";
 import type { CoreConfig, GroupMeConfig } from "./types.js";
 
+type GroupMeOnboardingApi = {
+  fetchGroups?: typeof fetchGroups;
+  createBot?: typeof createBot;
+};
+
 function readSecretInputString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -132,419 +137,433 @@ function redactMiddle(value: string): string {
   return `${value.slice(0, 6)}...${value.slice(-3)}`;
 }
 
-export const groupmeOnboardingAdapter: ChannelSetupWizardAdapter = {
-  channel: "groupme",
-  getStatus: async ({ cfg, accountOverrides }) => {
-    const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
-    const account = resolveGroupMeAccount({
-      cfg: cfg as CoreConfig,
-      accountId,
-    });
+export function createGroupMeOnboardingAdapter(
+  api: GroupMeOnboardingApi = {},
+): ChannelSetupWizardAdapter {
+  const fetchGroupsImpl = api.fetchGroups ?? fetchGroups;
+  const createBotImpl = api.createBot ?? createBot;
 
-    const configured = account.configured;
-    const webhookPathConfigured = Boolean(account.config.webhookPath?.trim());
-    const callbackTokenConfigured = hasSecretInput(account.config.callbackToken);
-    const groupIdConfigured = Boolean(account.config.groupId?.trim());
-    const publicDomainConfigured = Boolean(account.config.publicDomain?.trim());
-
-    return {
-      channel: "groupme",
-      configured,
-      statusLines: [
-        `GroupMe (${accountId}): ${configured ? "configured" : "needs access token"}`,
-        hasSecretInput(account.config.accessToken)
-          ? "Access token configured"
-          : "Access token missing",
-        webhookPathConfigured ? "Webhook path configured" : "Webhook path missing",
-        callbackTokenConfigured ? "Callback token configured" : "Callback token missing",
-        publicDomainConfigured ? "Public domain configured" : "Public domain missing",
-        groupIdConfigured ? "Group ID configured" : "Group ID missing",
-      ],
-      selectionHint: configured ? "configured" : "needs access token",
-      quickstartScore: configured ? 1 : 0,
-    };
-  },
-  configure: async ({ cfg, prompter, accountOverrides }) => {
-    const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
-
-    const botNameInput = (
-      await prompter.text({
-        message: "Bot name",
-        initialValue: "openclaw",
-      })
-    ).trim();
-    const botName = botNameInput || "openclaw";
-
-    const accessToken = (
-      await prompter.text({
-        message: "GroupMe access token",
-        validate: (value) => (value.trim() ? undefined : "Access token is required"),
-      })
-    ).trim();
-
-    const groupsSpin = prompter.progress("Fetching your GroupMe groups...");
-    let groups: Awaited<ReturnType<typeof fetchGroups>>;
-    try {
-      groups = await fetchGroups(accessToken);
-    } catch {
-      groupsSpin.stop("Failed");
-      await prompter.note(
-        "Could not fetch groups. Check your access token and try again.",
-        "GroupMe setup failed",
-      );
-      throw new Error("Could not fetch groups");
-    }
-
-    if (groups.length === 0) {
-      groupsSpin.stop("No groups found");
-      await prompter.note(
-        "No groups found. Create or join a GroupMe group first.",
-        "GroupMe setup failed",
-      );
-      throw new Error("No GroupMe groups found");
-    }
-    groupsSpin.stop(`Found ${groups.length} groups`);
-
-    const groupId = await prompter.select<string>({
-      message: "Select a GroupMe group",
-      options: groups.map((group) => ({
-        value: group.id,
-        label: group.name || group.id,
-        hint: group.id,
-      })),
-    });
-    const selectedGroup = groups.find((group) => group.id === groupId);
-    const requireMention = await prompter.confirm({
-      message: "Require mention to respond?",
-      initialValue: true,
-    });
-    const publicDomainRaw = (
-      await prompter.text({
-        message: "Public domain (must be reachable — GroupMe will ping it)",
-        validate: validatePublicDomainInput,
-      })
-    ).trim();
-    const publicDomain = requirePublicDomain(publicDomainRaw);
-
-    const { webhookPath, callbackToken } = generateCallbackSettings();
-    const pathSegment = webhookPath.split("/").pop() ?? webhookPath;
-    await prompter.note(
-      `Generated webhook URL path and token placeholder: /groupme/${pathSegment}?k=***`,
-      "Generated webhook settings",
-    );
-
-    const botSpin = prompter.progress("Registering bot with GroupMe...");
-    let botId = "";
-    try {
-      const bot = await createBot({
-        accessToken,
-        name: botName,
-        groupId,
-        callbackUrl: buildPublicCallbackUrl({
-          publicDomain,
-          webhookPath,
-          callbackToken,
-        }),
+  const adapter: ChannelSetupWizardAdapter = {
+    channel: "groupme",
+    getStatus: async ({ cfg, accountOverrides }) => {
+      const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
+      const account = resolveGroupMeAccount({
+        cfg: cfg as CoreConfig,
+        accountId,
       });
-      botId = bot.bot_id;
-      botSpin.stop("Bot registered");
-    } catch (error) {
-      botSpin.stop("Failed");
-      const detail = error instanceof Error ? `\n\nDetails: ${error.message}` : "";
-      await prompter.note(
-        `Failed to register bot with GroupMe. Check your access token and try again.${detail}`,
-        "GroupMe setup failed",
-      );
-      throw new Error("Failed to register GroupMe bot", {
-        cause: error instanceof Error ? error : undefined,
-      });
-    }
 
-    await prompter.note(
-      `Bot "${botName}" registered in group "${selectedGroup?.name ?? groupId}" (bot ID: ${redactMiddle(botId)})`,
-      "GroupMe bot registered",
-    );
+      const configured = account.configured;
+      const webhookPathConfigured = Boolean(account.config.webhookPath?.trim());
+      const callbackTokenConfigured = hasSecretInput(account.config.callbackToken);
+      const groupIdConfigured = Boolean(account.config.groupId?.trim());
+      const publicDomainConfigured = Boolean(account.config.publicDomain?.trim());
 
-    const next = applyGroupMeConfig({
-      cfg,
-      accountId,
-      updates: {
-        botName,
-        accessToken,
-        botId,
-        groupId,
-        publicDomain,
-        webhookPath,
-        callbackToken,
-        requireMention,
-      },
-    });
+      return {
+        channel: "groupme",
+        configured,
+        statusLines: [
+          `GroupMe (${accountId}): ${configured ? "configured" : "needs access token"}`,
+          hasSecretInput(account.config.accessToken)
+            ? "Access token configured"
+            : "Access token missing",
+          webhookPathConfigured ? "Webhook path configured" : "Webhook path missing",
+          callbackTokenConfigured ? "Callback token configured" : "Callback token missing",
+          publicDomainConfigured ? "Public domain configured" : "Public domain missing",
+          groupIdConfigured ? "Group ID configured" : "Group ID missing",
+        ],
+        selectionHint: configured ? "configured" : "needs access token",
+        quickstartScore: configured ? 1 : 0,
+      };
+    },
+    configure: async ({ cfg, prompter, accountOverrides }) => {
+      const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
 
-    await prompter.note(
-      [
-        "Next steps:",
-        "1. Restart the gateway: openclaw gateway restart",
-        "2. Send a message in the group to test",
-      ].join("\n"),
-      "GroupMe next steps",
-    );
-
-    return {
-      cfg: next,
-      accountId,
-    };
-  },
-  configureWhenConfigured: async ({ cfg, prompter, runtime, accountOverrides }) => {
-    const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
-    const account = resolveGroupMeAccount({
-      cfg: cfg as CoreConfig,
-      accountId,
-    });
-
-    const action = await prompter.select<string>({
-      message: "GroupMe is already configured. What would you like to do?",
-      options: [
-        { value: "skip", label: "Skip", hint: "no changes" },
-        { value: "rotate_token", label: "Rotate access token" },
-        { value: "change_group", label: "Change group" },
-        { value: "regen_callback", label: "Regenerate webhook settings" },
-        { value: "toggle_mention", label: "Toggle requireMention" },
-        { value: "update_domain", label: "Update public domain" },
-        { value: "full_setup", label: "Full re-setup", hint: "start from scratch" },
-      ],
-    });
-
-    if (action === "skip") {
-      return "skip";
-    }
-
-    if (action === "full_setup") {
-      return groupmeOnboardingAdapter.configure({
-        cfg,
-        prompter,
-        runtime,
-        accountOverrides,
-        options: {},
-        shouldPromptAccountIds: false,
-        forceAllowFrom: false,
-      });
-    }
-
-    if (action === "rotate_token") {
-      const newToken = (
+      const botNameInput = (
         await prompter.text({
-          message: "New GroupMe access token",
+          message: "Bot name",
+          initialValue: "openclaw",
+        })
+      ).trim();
+      const botName = botNameInput || "openclaw";
+
+      const accessToken = (
+        await prompter.text({
+          message: "GroupMe access token",
           validate: (value) => (value.trim() ? undefined : "Access token is required"),
         })
       ).trim();
 
-      const spin = prompter.progress("Validating access token...");
-      try {
-        await fetchGroups(newToken);
-        spin.stop("Token validated");
-      } catch {
-        spin.stop("Failed");
-        await prompter.note(
-          "Could not validate token. Check your access token and try again.",
-          "Validation failed",
-        );
-        throw new Error("Could not validate access token");
-      }
-
-      const next = applyGroupMeConfig({
-        cfg,
-        accountId,
-        updates: { accessToken: newToken },
-      });
-      await prompter.note("Access token updated.", "Token rotated");
-      return { cfg: next, accountId };
-    }
-
-    if (action === "change_group") {
-      const existingToken = account.accessToken;
-      if (!existingToken) {
-        await prompter.note(
-          'No access token configured. Use "Rotate access token" first.',
-          "Missing token",
-        );
-        return "skip";
-      }
-
-      const spin = prompter.progress("Fetching your GroupMe groups...");
+      const groupsSpin = prompter.progress("Fetching your GroupMe groups...");
       let groups: Awaited<ReturnType<typeof fetchGroups>>;
       try {
-        groups = await fetchGroups(existingToken);
+        groups = await fetchGroupsImpl(accessToken);
       } catch {
-        spin.stop("Failed");
+        groupsSpin.stop("Failed");
         await prompter.note(
           "Could not fetch groups. Check your access token and try again.",
-          "GroupMe error",
+          "GroupMe setup failed",
         );
         throw new Error("Could not fetch groups");
       }
 
       if (groups.length === 0) {
-        spin.stop("No groups found");
-        await prompter.note("No groups found. Create or join a GroupMe group first.", "No groups");
-        return "skip";
+        groupsSpin.stop("No groups found");
+        await prompter.note(
+          "No groups found. Create or join a GroupMe group first.",
+          "GroupMe setup failed",
+        );
+        throw new Error("No GroupMe groups found");
       }
-      spin.stop(`Found ${groups.length} groups`);
+      groupsSpin.stop(`Found ${groups.length} groups`);
 
-      const newGroupId = await prompter.select<string>({
+      const groupId = await prompter.select<string>({
         message: "Select a GroupMe group",
         options: groups.map((group) => ({
           value: group.id,
           label: group.name || group.id,
-          hint: group.id === account.config.groupId ? "current" : group.id,
+          hint: group.id,
         })),
       });
-
-      const selectedGroup = groups.find((g) => g.id === newGroupId);
-      const updates: Record<string, unknown> = { groupId: newGroupId };
-
-      const registerNew = await prompter.confirm({
-        message: "Register a new bot in this group?",
+      const selectedGroup = groups.find((group) => group.id === groupId);
+      const requireMention = await prompter.confirm({
+        message: "Require mention to respond?",
         initialValue: true,
       });
-
-      if (!registerNew) {
-        const newBotId = (
-          await prompter.text({
-            message: "Bot ID for the new group (existing bot won't work in a different group)",
-            validate: (value) => (value.trim() ? undefined : "Bot ID is required"),
-          })
-        ).trim();
-        updates.botId = newBotId;
-      }
-
-      if (registerNew) {
-        const botName = account.config.botName || "openclaw";
-        let publicDomain = account.config.publicDomain;
-        if (!publicDomain) {
-          const domainRaw = (
-            await prompter.text({
-              message: "Public domain (required for bot registration)",
-              validate: validatePublicDomainInput,
-            })
-          ).trim();
-          publicDomain = requirePublicDomain(domainRaw);
-          updates.publicDomain = publicDomain;
-        }
-        let webhookPath = account.config.webhookPath?.trim();
-        let callbackToken = readSecretInputString(account.config.callbackToken);
-        const hasSecretBackedCallbackToken =
-          !callbackToken && hasSecretInput(account.config.callbackToken);
-        if (hasSecretBackedCallbackToken) {
-          await prompter.note(
-            [
-              "Callback token is configured as a secret reference.",
-              "Re-registering a GroupMe bot requires the literal callback token to build the callback URL.",
-              "Regenerate webhook settings or update the bot outside this setup flow.",
-            ].join("\n"),
-            "Secret callback token",
-          );
-          return "skip";
-        }
-        if (!webhookPath || !callbackToken) {
-          const generated = generateCallbackSettings();
-          webhookPath = webhookPath || generated.webhookPath;
-          callbackToken = callbackToken || generated.callbackToken;
-          updates.webhookPath = webhookPath;
-          updates.callbackToken = callbackToken;
-        }
-
-        const botSpin = prompter.progress("Registering bot with GroupMe...");
-        try {
-          const bot = await createBot({
-            accessToken: existingToken,
-            name: botName,
-            groupId: newGroupId,
-            callbackUrl: buildPublicCallbackUrl({
-              publicDomain,
-              webhookPath,
-              callbackToken,
-            }),
-          });
-          updates.botId = bot.bot_id;
-          botSpin.stop("Bot registered");
-        } catch (error) {
-          botSpin.stop("Failed");
-          const detail = error instanceof Error ? `\n\nDetails: ${error.message}` : "";
-          await prompter.note(`Failed to register bot.${detail}`, "Bot registration failed");
-          throw new Error("Failed to register GroupMe bot", {
-            cause: error instanceof Error ? error : undefined,
-          });
-        }
-      }
-
-      const next = applyGroupMeConfig({ cfg, accountId, updates });
-      await prompter.note(
-        `Group changed to "${selectedGroup?.name ?? newGroupId}".`,
-        "Group updated",
-      );
-      return { cfg: next, accountId };
-    }
-
-    if (action === "regen_callback") {
-      const { webhookPath, callbackToken } = generateCallbackSettings();
-      const next = applyGroupMeConfig({
-        cfg,
-        accountId,
-        updates: { webhookPath, callbackToken },
-      });
-      await prompter.note(
-        [
-          "Webhook path and callback token regenerated.",
-          "Remember to update your GroupMe bot settings or re-register the bot.",
-        ].join("\n"),
-        "Webhook settings updated",
-      );
-      return { cfg: next, accountId };
-    }
-
-    if (action === "toggle_mention") {
-      const current = account.config.requireMention ?? true;
-      const next = applyGroupMeConfig({
-        cfg,
-        accountId,
-        updates: { requireMention: !current },
-      });
-      await prompter.note(
-        `requireMention changed from ${current} to ${!current}.`,
-        "Mention setting updated",
-      );
-      return { cfg: next, accountId };
-    }
-
-    if (action === "update_domain") {
-      const newDomainRaw = (
+      const publicDomainRaw = (
         await prompter.text({
-          message: "New public domain",
-          initialValue: account.config.publicDomain ?? "",
+          message: "Public domain (must be reachable — GroupMe will ping it)",
           validate: validatePublicDomainInput,
         })
       ).trim();
+      const publicDomain = requirePublicDomain(publicDomainRaw);
 
-      const publicDomain = requirePublicDomain(newDomainRaw);
+      const { webhookPath, callbackToken } = generateCallbackSettings();
+      const pathSegment = webhookPath.split("/").pop() ?? webhookPath;
+      await prompter.note(
+        `Generated webhook URL path and token placeholder: /groupme/${pathSegment}?k=***`,
+        "Generated webhook settings",
+      );
+
+      const botSpin = prompter.progress("Registering bot with GroupMe...");
+      let botId = "";
+      try {
+        const bot = await createBotImpl({
+          accessToken,
+          name: botName,
+          groupId,
+          callbackUrl: buildPublicCallbackUrl({
+            publicDomain,
+            webhookPath,
+            callbackToken,
+          }),
+        });
+        botId = bot.bot_id;
+        botSpin.stop("Bot registered");
+      } catch (error) {
+        botSpin.stop("Failed");
+        const detail = error instanceof Error ? `\n\nDetails: ${error.message}` : "";
+        await prompter.note(
+          `Failed to register bot with GroupMe. Check your access token and try again.${detail}`,
+          "GroupMe setup failed",
+        );
+        throw new Error("Failed to register GroupMe bot", {
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+
+      await prompter.note(
+        `Bot "${botName}" registered in group "${selectedGroup?.name ?? groupId}" (bot ID: ${redactMiddle(botId)})`,
+        "GroupMe bot registered",
+      );
+
       const next = applyGroupMeConfig({
         cfg,
         accountId,
-        updates: { publicDomain },
+        updates: {
+          botName,
+          accessToken,
+          botId,
+          groupId,
+          publicDomain,
+          webhookPath,
+          callbackToken,
+          requireMention,
+        },
       });
-      await prompter.note(`Public domain updated to "${publicDomain}".`, "Domain updated");
-      return { cfg: next, accountId };
-    }
 
-    return "skip";
-  },
-  disable: (cfg) => ({
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      groupme: {
-        ...(cfg.channels?.groupme ?? {}),
-        enabled: false,
-      },
+      await prompter.note(
+        [
+          "Next steps:",
+          "1. Restart the gateway: openclaw gateway restart",
+          "2. Send a message in the group to test",
+        ].join("\n"),
+        "GroupMe next steps",
+      );
+
+      return {
+        cfg: next,
+        accountId,
+      };
     },
-  }),
-};
+    configureWhenConfigured: async ({ cfg, prompter, runtime, accountOverrides }) => {
+      const accountId = accountOverrides.groupme ?? DEFAULT_ACCOUNT_ID;
+      const account = resolveGroupMeAccount({
+        cfg: cfg as CoreConfig,
+        accountId,
+      });
+
+      const action = await prompter.select<string>({
+        message: "GroupMe is already configured. What would you like to do?",
+        options: [
+          { value: "skip", label: "Skip", hint: "no changes" },
+          { value: "rotate_token", label: "Rotate access token" },
+          { value: "change_group", label: "Change group" },
+          { value: "regen_callback", label: "Regenerate webhook settings" },
+          { value: "toggle_mention", label: "Toggle requireMention" },
+          { value: "update_domain", label: "Update public domain" },
+          { value: "full_setup", label: "Full re-setup", hint: "start from scratch" },
+        ],
+      });
+
+      if (action === "skip") {
+        return "skip";
+      }
+
+      if (action === "full_setup") {
+        return adapter.configure({
+          cfg,
+          prompter,
+          runtime,
+          accountOverrides,
+          options: {},
+          shouldPromptAccountIds: false,
+          forceAllowFrom: false,
+        });
+      }
+
+      if (action === "rotate_token") {
+        const newToken = (
+          await prompter.text({
+            message: "New GroupMe access token",
+            validate: (value) => (value.trim() ? undefined : "Access token is required"),
+          })
+        ).trim();
+
+        const spin = prompter.progress("Validating access token...");
+        try {
+          await fetchGroupsImpl(newToken);
+          spin.stop("Token validated");
+        } catch {
+          spin.stop("Failed");
+          await prompter.note(
+            "Could not validate token. Check your access token and try again.",
+            "Validation failed",
+          );
+          throw new Error("Could not validate access token");
+        }
+
+        const next = applyGroupMeConfig({
+          cfg,
+          accountId,
+          updates: { accessToken: newToken },
+        });
+        await prompter.note("Access token updated.", "Token rotated");
+        return { cfg: next, accountId };
+      }
+
+      if (action === "change_group") {
+        const existingToken = account.accessToken;
+        if (!existingToken) {
+          await prompter.note(
+            'No access token configured. Use "Rotate access token" first.',
+            "Missing token",
+          );
+          return "skip";
+        }
+
+        const spin = prompter.progress("Fetching your GroupMe groups...");
+        let groups: Awaited<ReturnType<typeof fetchGroups>>;
+        try {
+          groups = await fetchGroupsImpl(existingToken);
+        } catch {
+          spin.stop("Failed");
+          await prompter.note(
+            "Could not fetch groups. Check your access token and try again.",
+            "GroupMe error",
+          );
+          throw new Error("Could not fetch groups");
+        }
+
+        if (groups.length === 0) {
+          spin.stop("No groups found");
+          await prompter.note(
+            "No groups found. Create or join a GroupMe group first.",
+            "No groups",
+          );
+          return "skip";
+        }
+        spin.stop(`Found ${groups.length} groups`);
+
+        const newGroupId = await prompter.select<string>({
+          message: "Select a GroupMe group",
+          options: groups.map((group) => ({
+            value: group.id,
+            label: group.name || group.id,
+            hint: group.id === account.config.groupId ? "current" : group.id,
+          })),
+        });
+
+        const selectedGroup = groups.find((g) => g.id === newGroupId);
+        const updates: Record<string, unknown> = { groupId: newGroupId };
+
+        const registerNew = await prompter.confirm({
+          message: "Register a new bot in this group?",
+          initialValue: true,
+        });
+
+        if (!registerNew) {
+          const newBotId = (
+            await prompter.text({
+              message: "Bot ID for the new group (existing bot won't work in a different group)",
+              validate: (value) => (value.trim() ? undefined : "Bot ID is required"),
+            })
+          ).trim();
+          updates.botId = newBotId;
+        }
+
+        if (registerNew) {
+          const botName = account.config.botName || "openclaw";
+          let publicDomain = account.config.publicDomain;
+          if (!publicDomain) {
+            const domainRaw = (
+              await prompter.text({
+                message: "Public domain (required for bot registration)",
+                validate: validatePublicDomainInput,
+              })
+            ).trim();
+            publicDomain = requirePublicDomain(domainRaw);
+            updates.publicDomain = publicDomain;
+          }
+          let webhookPath = account.config.webhookPath?.trim();
+          let callbackToken = readSecretInputString(account.config.callbackToken);
+          const hasSecretBackedCallbackToken =
+            !callbackToken && hasSecretInput(account.config.callbackToken);
+          if (hasSecretBackedCallbackToken) {
+            await prompter.note(
+              [
+                "Callback token is configured as a secret reference.",
+                "Re-registering a GroupMe bot requires the literal callback token to build the callback URL.",
+                "Regenerate webhook settings or update the bot outside this setup flow.",
+              ].join("\n"),
+              "Secret callback token",
+            );
+            return "skip";
+          }
+          if (!webhookPath || !callbackToken) {
+            const generated = generateCallbackSettings();
+            webhookPath = webhookPath || generated.webhookPath;
+            callbackToken = callbackToken || generated.callbackToken;
+            updates.webhookPath = webhookPath;
+            updates.callbackToken = callbackToken;
+          }
+
+          const botSpin = prompter.progress("Registering bot with GroupMe...");
+          try {
+            const bot = await createBotImpl({
+              accessToken: existingToken,
+              name: botName,
+              groupId: newGroupId,
+              callbackUrl: buildPublicCallbackUrl({
+                publicDomain,
+                webhookPath,
+                callbackToken,
+              }),
+            });
+            updates.botId = bot.bot_id;
+            botSpin.stop("Bot registered");
+          } catch (error) {
+            botSpin.stop("Failed");
+            const detail = error instanceof Error ? `\n\nDetails: ${error.message}` : "";
+            await prompter.note(`Failed to register bot.${detail}`, "Bot registration failed");
+            throw new Error("Failed to register GroupMe bot", {
+              cause: error instanceof Error ? error : undefined,
+            });
+          }
+        }
+
+        const next = applyGroupMeConfig({ cfg, accountId, updates });
+        await prompter.note(
+          `Group changed to "${selectedGroup?.name ?? newGroupId}".`,
+          "Group updated",
+        );
+        return { cfg: next, accountId };
+      }
+
+      if (action === "regen_callback") {
+        const { webhookPath, callbackToken } = generateCallbackSettings();
+        const next = applyGroupMeConfig({
+          cfg,
+          accountId,
+          updates: { webhookPath, callbackToken },
+        });
+        await prompter.note(
+          [
+            "Webhook path and callback token regenerated.",
+            "Remember to update your GroupMe bot settings or re-register the bot.",
+          ].join("\n"),
+          "Webhook settings updated",
+        );
+        return { cfg: next, accountId };
+      }
+
+      if (action === "toggle_mention") {
+        const current = account.config.requireMention ?? true;
+        const next = applyGroupMeConfig({
+          cfg,
+          accountId,
+          updates: { requireMention: !current },
+        });
+        await prompter.note(
+          `requireMention changed from ${current} to ${!current}.`,
+          "Mention setting updated",
+        );
+        return { cfg: next, accountId };
+      }
+
+      if (action === "update_domain") {
+        const newDomainRaw = (
+          await prompter.text({
+            message: "New public domain",
+            initialValue: account.config.publicDomain ?? "",
+            validate: validatePublicDomainInput,
+          })
+        ).trim();
+
+        const publicDomain = requirePublicDomain(newDomainRaw);
+        const next = applyGroupMeConfig({
+          cfg,
+          accountId,
+          updates: { publicDomain },
+        });
+        await prompter.note(`Public domain updated to "${publicDomain}".`, "Domain updated");
+        return { cfg: next, accountId };
+      }
+
+      return "skip";
+    },
+    disable: (cfg) => ({
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        groupme: {
+          ...(cfg.channels?.groupme ?? {}),
+          enabled: false,
+        },
+      },
+    }),
+  };
+
+  return adapter;
+}
+
+export const groupmeOnboardingAdapter = createGroupMeOnboardingAdapter();

--- a/src/send.ts
+++ b/src/send.ts
@@ -33,8 +33,10 @@ export async function sendGroupMeMessage(params: {
   text: string;
   pictureUrl?: string;
   fetchFn?: FetchLike;
+  apiBaseUrl?: string;
 }): Promise<SendGroupMeResult> {
   const fetchFn = params.fetchFn ?? fetch;
+  const apiBaseUrl = params.apiBaseUrl ?? GROUPME_API_BASE;
   const payload: { bot_id: string; text: string; picture_url?: string } = {
     bot_id: params.botId,
     text: params.text,
@@ -42,7 +44,7 @@ export async function sendGroupMeMessage(params: {
   if (params.pictureUrl) {
     payload.picture_url = params.pictureUrl;
   }
-  const response = await fetchFn(`${GROUPME_API_BASE}/bots/post`, {
+  const response = await fetchFn(`${apiBaseUrl}/bots/post`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -71,9 +73,11 @@ export async function uploadGroupMeImage(params: {
   imageData: Buffer;
   contentType?: string;
   fetchFn?: FetchLike;
+  imageBaseUrl?: string;
 }): Promise<string> {
   const fetchFn = params.fetchFn ?? fetch;
-  const response = await fetchFn(`${GROUPME_IMAGE_SERVICE}/pictures`, {
+  const imageBaseUrl = params.imageBaseUrl ?? GROUPME_IMAGE_SERVICE;
+  const response = await fetchFn(`${imageBaseUrl}/pictures`, {
     method: "POST",
     headers: {
       "X-Access-Token": params.accessToken,
@@ -294,6 +298,7 @@ export async function sendGroupMeText(params: {
   text: string;
   accountId?: string | null;
   fetchFn?: FetchLike;
+  apiBaseUrl?: string;
 }): Promise<SendGroupMeResult> {
   const account = resolveGroupMeAccount({
     cfg: params.cfg,
@@ -307,6 +312,7 @@ export async function sendGroupMeText(params: {
     botId: account.botId,
     text: params.text,
     fetchFn: params.fetchFn,
+    apiBaseUrl: params.apiBaseUrl,
   });
 }
 
@@ -317,6 +323,8 @@ export async function sendGroupMeMedia(params: {
   mediaUrl: string;
   accountId?: string | null;
   fetchFn?: FetchLike;
+  apiBaseUrl?: string;
+  imageBaseUrl?: string;
 }): Promise<SendGroupMeResult> {
   const account = resolveGroupMeAccount({
     cfg: params.cfg,
@@ -347,6 +355,7 @@ export async function sendGroupMeMedia(params: {
     imageData: data,
     contentType,
     fetchFn: params.fetchFn,
+    imageBaseUrl: params.imageBaseUrl,
   });
 
   return sendGroupMeMessage({
@@ -354,5 +363,6 @@ export async function sendGroupMeMedia(params: {
     text: params.text,
     pictureUrl,
     fetchFn: params.fetchFn,
+    apiBaseUrl: params.apiBaseUrl,
   });
 }

--- a/tests/integration/groupme-http-boundary.test.ts
+++ b/tests/integration/groupme-http-boundary.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createBot, fetchGroups } from "../../src/groupme-api.js";
+import { sendGroupMeMessage, uploadGroupMeImage } from "../../src/send.js";
+import { startTestHttpServer, type TestHttpServer } from "./helpers/http.js";
+
+describe("GroupMe HTTP boundary", () => {
+  const servers: TestHttpServer[] = [];
+
+  async function server(
+    handler: Parameters<typeof startTestHttpServer>[0],
+  ): Promise<TestHttpServer> {
+    const next = await startTestHttpServer(handler);
+    servers.push(next);
+    return next;
+  }
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((next) => next.close()));
+  });
+
+  it("fetches groups with token, pagination, and omitted memberships", async () => {
+    const api = await server((request, response) => {
+      expect(request.path).toBe("/groups");
+      expect(request.query.get("token")).toBe("access-token");
+      expect(request.query.get("per_page")).toBe("100");
+      expect(request.query.get("omit")).toBe("memberships");
+
+      response.setHeader("content-type", "application/json");
+      if (request.query.get("page") === "1") {
+        response.end(JSON.stringify({ response: [{ id: "g1", name: "One" }] }));
+        return;
+      }
+      response.end(JSON.stringify({ response: [] }));
+    });
+
+    await expect(fetchGroups("access-token", { apiBaseUrl: api.baseUrl })).resolves.toEqual([
+      expect.objectContaining({ id: "g1", name: "One" }),
+    ]);
+    expect(api.requests.map((request) => request.query.get("page"))).toEqual(["1", "2"]);
+  });
+
+  it("creates a bot with the expected request shape", async () => {
+    const api = await server((request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.path).toBe("/bots");
+      expect(request.query.get("token")).toBe("access-token");
+      expect(request.headers["content-type"]).toContain("application/json");
+      expect(request.json).toEqual({
+        bot: {
+          name: "OpenClaw",
+          group_id: "group-1",
+          callback_url: "https://example.test/groupme?k=token",
+          active: true,
+        },
+      });
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ response: { bot: { bot_id: "bot-1" } } }));
+    });
+
+    await expect(
+      createBot({
+        accessToken: "access-token",
+        name: "OpenClaw",
+        groupId: "group-1",
+        callbackUrl: "https://example.test/groupme?k=token",
+        apiBaseUrl: api.baseUrl,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ bot_id: "bot-1" }));
+  });
+
+  it("posts outbound text to the Bot API", async () => {
+    const api = await server((request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.path).toBe("/bots/post");
+      expect(request.headers["content-type"]).toContain("application/json");
+      expect(request.json).toEqual({
+        bot_id: "bot-1",
+        text: "hello from integration",
+      });
+      response.statusCode = 202;
+      response.end("{}");
+    });
+
+    const result = await sendGroupMeMessage({
+      botId: "bot-1",
+      text: "hello from integration",
+      apiBaseUrl: api.baseUrl,
+    });
+
+    expect(result.messageId).toEqual(expect.any(String));
+    expect(result.timestamp).toEqual(expect.any(Number));
+  });
+
+  it("uploads image bytes to the Image Service and extracts the picture URL", async () => {
+    const image = await server((request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.path).toBe("/pictures");
+      expect(request.headers["x-access-token"]).toBe("access-token");
+      expect(request.headers["content-type"]).toBe("image/png");
+      expect(request.body).toBe("fake-image");
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ payload: { picture_url: "https://i.groupme.test/pic" } }));
+    });
+
+    await expect(
+      uploadGroupMeImage({
+        accessToken: "access-token",
+        imageData: Buffer.from("fake-image"),
+        contentType: "image/png",
+        imageBaseUrl: image.baseUrl,
+      }),
+    ).resolves.toBe("https://i.groupme.test/pic");
+  });
+});

--- a/tests/integration/helpers/http.ts
+++ b/tests/integration/helpers/http.ts
@@ -1,0 +1,85 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export type RecordedRequest = {
+  method: string;
+  path: string;
+  query: URLSearchParams;
+  headers: IncomingMessage["headers"];
+  body: string;
+  json: unknown;
+};
+
+export type TestHttpServer = {
+  baseUrl: string;
+  requests: RecordedRequest[];
+  close(): Promise<void>;
+};
+
+export async function startTestHttpServer(
+  handler: (request: RecordedRequest, response: ServerResponse) => void | Promise<void>,
+): Promise<TestHttpServer> {
+  const requests: RecordedRequest[] = [];
+  const server = createServer(async (incoming, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of incoming) {
+      chunks.push(Buffer.from(chunk));
+    }
+
+    const body = Buffer.concat(chunks).toString("utf8");
+    let json: unknown = null;
+    if (body) {
+      try {
+        json = JSON.parse(body);
+      } catch {
+        json = null;
+      }
+    }
+
+    const url = new URL(incoming.url ?? "/", "http://localhost");
+    const request: RecordedRequest = {
+      method: incoming.method ?? "",
+      path: url.pathname,
+      query: url.searchParams,
+      headers: incoming.headers,
+      body,
+      json,
+    };
+    requests.push(request);
+
+    try {
+      await handler(request, response);
+    } catch (error) {
+      response.statusCode = 500;
+      response.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Unable to determine test HTTP server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => closeServer(server),
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/tests/integration/helpers/http.ts
+++ b/tests/integration/helpers/http.ts
@@ -53,9 +53,9 @@ export async function startTestHttpServer(
 
     try {
       await handler(request, response);
-    } catch (error) {
+    } catch {
       response.statusCode = 500;
-      response.end(error instanceof Error ? error.message : String(error));
+      response.end("Internal Server Error");
     }
   });
 
@@ -84,9 +84,9 @@ export async function startNodeHandlerServer(
   handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
 ): Promise<NodeHandlerServer> {
   const server = createServer((request, response) => {
-    void Promise.resolve(handler(request, response)).catch((error) => {
+    void Promise.resolve(handler(request, response)).catch(() => {
       response.statusCode = 500;
-      response.end(error instanceof Error ? error.message : String(error));
+      response.end("Internal Server Error");
     });
   });
 

--- a/tests/integration/helpers/http.ts
+++ b/tests/integration/helpers/http.ts
@@ -15,6 +15,11 @@ export type TestHttpServer = {
   close(): Promise<void>;
 };
 
+export type NodeHandlerServer = {
+  baseUrl: string;
+  close(): Promise<void>;
+};
+
 export async function startTestHttpServer(
   handler: (request: RecordedRequest, response: ServerResponse) => void | Promise<void>,
 ): Promise<TestHttpServer> {
@@ -71,6 +76,36 @@ export async function startTestHttpServer(
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     requests,
+    close: () => closeServer(server),
+  };
+}
+
+export async function startNodeHandlerServer(
+  handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
+): Promise<NodeHandlerServer> {
+  const server = createServer((request, response) => {
+    void Promise.resolve(handler(request, response)).catch((error) => {
+      response.statusCode = 500;
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Unable to determine test HTTP server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
     close: () => closeServer(server),
   };
 }

--- a/tests/integration/helpers/package.ts
+++ b/tests/integration/helpers/package.ts
@@ -56,7 +56,9 @@ export function packDryRun(): PackDryRun {
     return dryRun;
   }
   buildPackage();
-  const output = runNpm(["pack", "--dry-run", "--json"]);
+  const output = runNpm(["pack", "--dry-run", "--json"], {
+    env: { npm_config_ignore_scripts: "true" },
+  });
   const parsed = parseNpmJsonArray<PackDryRun>(output);
   const [pack] = parsed;
   if (!pack) {
@@ -76,7 +78,9 @@ export function removeTempProject(path: string): void {
 
 export function packTarball(destination: string): string {
   buildPackage();
-  const output = runNpm(["pack", "--json", "--pack-destination", destination]);
+  const output = runNpm(["pack", "--json", "--pack-destination", destination], {
+    env: { npm_config_ignore_scripts: "true" },
+  });
   const parsed = parseNpmJsonArray<{ filename: string }>(output);
   const [pack] = parsed;
   if (!pack?.filename) {

--- a/tests/integration/helpers/package.ts
+++ b/tests/integration/helpers/package.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const repoRoot = resolve(here, "../../..");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCliPath = process.env.npm_execpath;
+
+let built = false;
+let dryRun: PackDryRun | null = null;
+
+export function run(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...options.env,
+    },
+    shell: process.platform === "win32" && command.endsWith(".cmd"),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function buildPackage(): void {
+  if (built) {
+    return;
+  }
+  runNpm(["run", "build"]);
+  built = true;
+}
+
+export type PackedFile = {
+  path: string;
+  size: number;
+  mode: number;
+};
+
+export type PackDryRun = {
+  filename: string;
+  files: PackedFile[];
+};
+
+export function packDryRun(): PackDryRun {
+  if (dryRun) {
+    return dryRun;
+  }
+  buildPackage();
+  const output = runNpm(["pack", "--dry-run", "--json"]);
+  const parsed = parseNpmJsonArray<PackDryRun>(output);
+  const [pack] = parsed;
+  if (!pack) {
+    throw new Error("npm pack --dry-run returned no package entries");
+  }
+  dryRun = pack;
+  return pack;
+}
+
+export function createTempProject(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export function removeTempProject(path: string): void {
+  rmSync(path, { recursive: true, force: true });
+}
+
+export function packTarball(destination: string): string {
+  buildPackage();
+  const output = runNpm(["pack", "--json", "--pack-destination", destination]);
+  const parsed = parseNpmJsonArray<{ filename: string }>(output);
+  const [pack] = parsed;
+  if (!pack?.filename) {
+    throw new Error("npm pack returned no tarball filename");
+  }
+  return join(destination, pack.filename);
+}
+
+function parseNpmJsonArray<T>(output: string): T[] {
+  const start = output.indexOf("[");
+  const end = output.lastIndexOf("]");
+  if (start < 0 || end < start) {
+    throw new Error(`Unable to find JSON array in npm output: ${output}`);
+  }
+  return JSON.parse(output.slice(start, end + 1)) as T[];
+}
+
+export function readRootPackageJson(): {
+  files: string[];
+  openclaw: {
+    extensions: string[];
+    setupEntry: string;
+    compat: { pluginApi: string };
+  };
+  peerDependencies: Record<string, string>;
+  engines: Record<string, string>;
+} {
+  return JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+}
+
+export function assertExistsInRepo(relativePath: string): void {
+  if (!existsSync(join(repoRoot, relativePath))) {
+    throw new Error(`Expected ${relativePath} to exist in the repository`);
+  }
+}
+
+export async function importBuilt<T>(relativePath: string): Promise<T> {
+  buildPackage();
+  return import(pathToFileURL(join(repoRoot, relativePath)).href) as Promise<T>;
+}
+
+export function runNpm(args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
+  if (npmCliPath) {
+    return run(process.execPath, [npmCliPath, ...args], options);
+  }
+  return run(npmCommand, args, options);
+}

--- a/tests/integration/install-smoke.test.ts
+++ b/tests/integration/install-smoke.test.ts
@@ -1,0 +1,69 @@
+import { writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createTempProject,
+  packTarball,
+  removeTempProject,
+  repoRoot,
+  run,
+  runNpm,
+} from "./helpers/package.js";
+
+describe("installed package smoke test", () => {
+  let tempProject: string;
+
+  beforeAll(() => {
+    tempProject = createTempProject("openclaw-groupme-install-");
+    const tarball = packTarball(tempProject);
+    const openclawPath = resolve(repoRoot, "node_modules/openclaw");
+
+    writeFileSync(
+      join(tempProject, "package.json"),
+      JSON.stringify({ private: true, type: "module" }, null, 2),
+    );
+
+    runNpm(["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball, openclawPath], {
+      cwd: tempProject,
+    });
+  }, 120_000);
+
+  afterAll(() => {
+    removeTempProject(tempProject);
+  });
+
+  it("imports the installed runtime, setup, channel, and secret sidecars", () => {
+    const script = `
+      import assert from "node:assert/strict";
+      import entry from "openclaw-groupme/dist/index.js";
+      import setupEntry from "openclaw-groupme/dist/setup-entry.js";
+      import { groupmePlugin } from "openclaw-groupme/dist/channel-plugin-api.js";
+      import { channelSecrets } from "openclaw-groupme/dist/secret-contract-api.js";
+
+      assert.equal(entry.kind, "bundled-channel-entry");
+      assert.equal(entry.id, "groupme");
+      assert.equal(typeof entry.loadChannelPlugin, "function");
+      assert.equal(typeof entry.loadChannelSecrets, "function");
+      assert.equal(typeof entry.setChannelRuntime, "function");
+
+      assert.equal(setupEntry.kind, "bundled-channel-setup-entry");
+      assert.equal(groupmePlugin.id, "groupme");
+      assert.equal(typeof groupmePlugin.gateway.startAccount, "function");
+      assert.equal(typeof groupmePlugin.setupWizard.configure, "function");
+
+      const ids = channelSecrets.secretTargetRegistryEntries.map((entry) => entry.id).sort();
+      assert.deepEqual(ids, [
+        "channels.groupme.accessToken",
+        "channels.groupme.accounts.*.accessToken",
+        "channels.groupme.accounts.*.botId",
+        "channels.groupme.accounts.*.callbackToken",
+        "channels.groupme.botId",
+        "channels.groupme.callbackToken",
+      ]);
+    `;
+
+    expect(() =>
+      run("node", ["--input-type=module", "--eval", script], { cwd: tempProject }),
+    ).not.toThrow();
+  });
+});

--- a/tests/integration/onboarding-http-boundary.test.ts
+++ b/tests/integration/onboarding-http-boundary.test.ts
@@ -1,0 +1,168 @@
+import type { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBot, fetchGroups } from "../../src/groupme-api.js";
+import { createGroupMeOnboardingAdapter } from "../../src/onboarding.js";
+import { startTestHttpServer, type TestHttpServer } from "./helpers/http.js";
+
+function makeRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number) => {
+      throw new Error(`exit(${code})`);
+    }) as RuntimeEnv["exit"],
+  };
+}
+
+function makePrompter() {
+  const progressSpins: Array<{ update: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> =
+    [];
+  const progress = vi.fn((_label: string) => {
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    progressSpins.push(spin);
+    return spin;
+  });
+
+  const prompter: WizardPrompter = {
+    intro: vi.fn(async () => undefined),
+    outro: vi.fn(async () => undefined),
+    note: vi.fn(async () => undefined),
+    select: vi.fn(async () => "") as WizardPrompter["select"],
+    multiselect: vi.fn(async () => []) as WizardPrompter["multiselect"],
+    text: vi.fn(async () => "") as WizardPrompter["text"],
+    confirm: vi.fn(async () => true),
+    progress,
+  };
+
+  return { prompter, progressSpins };
+}
+
+function group(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: "",
+    image_url: null,
+    creator_user_id: "user-1",
+    created_at: 1,
+    updated_at: 1,
+    messages: {
+      count: 0,
+      last_message_created_at: 0,
+      preview: {
+        nickname: "",
+        text: "",
+      },
+    },
+  };
+}
+
+describe("GroupMe onboarding HTTP boundary", () => {
+  let api: TestHttpServer | null = null;
+
+  afterEach(async () => {
+    await api?.close();
+    api = null;
+  });
+
+  it("fetches groups, creates the selected bot, and saves split webhook settings", async () => {
+    api = await startTestHttpServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+
+      if (request.method === "GET" && request.path === "/groups") {
+        expect(request.query.get("token")).toBe("access-token");
+        expect(request.query.get("per_page")).toBe("100");
+        expect(request.query.get("omit")).toBe("memberships");
+        if (request.query.get("page") === "1") {
+          response.end(JSON.stringify({ response: [group("g1", "Family"), group("g2", "Work")] }));
+          return;
+        }
+        response.end(JSON.stringify({ response: [] }));
+        return;
+      }
+
+      if (request.method === "POST" && request.path === "/bots") {
+        expect(request.query.get("token")).toBe("access-token");
+        const bot = (request.json as { bot?: Record<string, unknown> }).bot;
+        expect(bot).toEqual(
+          expect.objectContaining({
+            name: "oddclaw",
+            group_id: "g2",
+            active: true,
+          }),
+        );
+        expect(String(bot?.callback_url)).toMatch(
+          /^https:\/\/bot\.example\.com\/groupme\/[0-9a-f]{16}\?k=[0-9a-f]{64}$/,
+        );
+        response.end(
+          JSON.stringify({
+            response: {
+              bot: {
+                bot_id: "bot-1234567890",
+                group_id: "g2",
+                name: "oddclaw",
+                callback_url: bot?.callback_url,
+                active: true,
+              },
+            },
+          }),
+        );
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end(JSON.stringify({ meta: { errors: ["not found"] } }));
+    });
+
+    const adapter = createGroupMeOnboardingAdapter({
+      fetchGroups: (accessToken) => fetchGroups(accessToken, { apiBaseUrl: api?.baseUrl }),
+      createBot: (params) => createBot({ ...params, apiBaseUrl: api?.baseUrl }),
+    });
+    const { prompter, progressSpins } = makePrompter();
+    (prompter.text as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce("oddclaw")
+      .mockResolvedValueOnce("access-token")
+      .mockResolvedValueOnce("https://bot.example.com");
+    (prompter.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce("g2");
+    (prompter.confirm as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+    const result = await adapter.configure({
+      cfg: { channels: {} } as OpenClawConfig,
+      runtime: makeRuntime(),
+      prompter,
+      options: {},
+      accountOverrides: { groupme: DEFAULT_ACCOUNT_ID },
+      shouldPromptAccountIds: false,
+      forceAllowFrom: false,
+    });
+
+    const section = result.cfg.channels?.groupme as Record<string, unknown>;
+    expect(result.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    expect(section).toEqual(
+      expect.objectContaining({
+        botId: "bot-1234567890",
+        accessToken: "access-token",
+        botName: "oddclaw",
+        groupId: "g2",
+        publicDomain: "bot.example.com",
+        requireMention: false,
+      }),
+    );
+    expect(section.webhookPath).toEqual(expect.stringMatching(/^\/groupme\/[0-9a-f]{16}$/));
+    expect(section.callbackToken).toEqual(expect.stringMatching(/^[0-9a-f]{64}$/));
+    expect(`${section.webhookPath as string}?k=${section.callbackToken as string}`).not.toBe(
+      section.webhookPath,
+    );
+    expect(progressSpins.map((spin) => spin.stop.mock.calls[0]?.[0])).toEqual([
+      "Found 2 groups",
+      "Bot registered",
+    ]);
+    expect(api.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /groups",
+      "GET /groups",
+      "POST /bots",
+    ]);
+  });
+});

--- a/tests/integration/openclaw-cli-smoke.test.ts
+++ b/tests/integration/openclaw-cli-smoke.test.ts
@@ -21,7 +21,7 @@ function isolatedOpenClawEnv(home: string): NodeJS.ProcessEnv {
 }
 
 describe("OpenClaw CLI plugin smoke", () => {
-  it("installs the packed plugin and inspects it through OpenClaw v2026.6.1", () => {
+  it("installs, configures, inspects, and dry-runs the channel through OpenClaw v2026.6.1", () => {
     const tempHome = createTempProject("openclaw-groupme-cli-");
     try {
       const tarball = packTarball(tempHome);
@@ -67,6 +67,121 @@ describe("OpenClaw CLI plugin smoke", () => {
       expect(
         inspected.diagnostics?.filter((entry) => (entry as { level?: string }).level === "error"),
       ).toEqual([]);
+
+      const allChannelsOutput = run(
+        process.execPath,
+        [openclawCli, "channels", "list", "--all", "--json"],
+        {
+          env,
+        },
+      );
+      const allChannels = JSON.parse(allChannelsOutput) as {
+        chat?: Record<string, { installed?: boolean; origin?: string }>;
+      };
+      expect(allChannels.chat?.groupme).toEqual(
+        expect.objectContaining({
+          installed: true,
+          origin: "available",
+        }),
+      );
+
+      run(
+        process.execPath,
+        [
+          openclawCli,
+          "channels",
+          "add",
+          "--channel",
+          "groupme",
+          "--token",
+          "fake-bot",
+          "--account",
+          "default",
+          "--name",
+          "Probe",
+        ],
+        { env },
+      );
+
+      const groupmeConfigOutput = run(
+        process.execPath,
+        [openclawCli, "config", "get", "channels.groupme", "--json"],
+        { env },
+      );
+      const groupmeConfig = JSON.parse(groupmeConfigOutput) as {
+        enabled?: boolean;
+        name?: string;
+        botId?: string;
+      };
+      expect(groupmeConfig).toEqual(
+        expect.objectContaining({
+          enabled: true,
+          name: "Probe",
+          botId: "fake-bot",
+        }),
+      );
+
+      const configuredChannelsOutput = run(
+        process.execPath,
+        [openclawCli, "channels", "list", "--json"],
+        { env },
+      );
+      const configuredChannels = JSON.parse(configuredChannelsOutput) as {
+        chat?: Record<string, { accounts?: string[]; installed?: boolean; origin?: string }>;
+      };
+      expect(configuredChannels.chat?.groupme).toEqual(
+        expect.objectContaining({
+          accounts: ["default"],
+          installed: true,
+          origin: "configured",
+        }),
+      );
+
+      const statusOutput = run(
+        process.execPath,
+        [openclawCli, "channels", "status", "--channel", "groupme", "--json"],
+        { env },
+      );
+      const status = JSON.parse(statusOutput) as {
+        configOnly?: boolean;
+        configuredChannels?: string[];
+      };
+      expect(status.configOnly).toBe(true);
+      expect(status.configuredChannels).toContain("groupme");
+
+      const dryRunOutput = run(
+        process.execPath,
+        [
+          openclawCli,
+          "message",
+          "send",
+          "--channel",
+          "groupme",
+          "--target",
+          "123",
+          "--message",
+          "probe",
+          "--dry-run",
+          "--json",
+        ],
+        { env },
+      );
+      const dryRun = JSON.parse(dryRunOutput) as {
+        action?: string;
+        channel?: string;
+        dryRun?: boolean;
+        payload?: {
+          to?: string;
+        };
+      };
+      expect(dryRun).toEqual(
+        expect.objectContaining({
+          action: "send",
+          channel: "groupme",
+          dryRun: true,
+        }),
+      );
+      expect(dryRun.payload?.to).toBe("123");
     } finally {
       removeTempProject(tempHome);
     }

--- a/tests/integration/openclaw-cli-smoke.test.ts
+++ b/tests/integration/openclaw-cli-smoke.test.ts
@@ -1,0 +1,74 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createTempProject,
+  packTarball,
+  removeTempProject,
+  repoRoot,
+  run,
+} from "./helpers/package.js";
+
+function isolatedOpenClawEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    CODEX_HOME: home,
+    NO_COLOR: "1",
+    OPENCLAW_DISABLE_BONJOUR: "1",
+    VITEST: "",
+    VITEST_WORKER_ID: "",
+  };
+}
+
+describe("OpenClaw CLI plugin smoke", () => {
+  it("installs the packed plugin and inspects it through OpenClaw v2026.6.1", () => {
+    const tempHome = createTempProject("openclaw-groupme-cli-");
+    try {
+      const tarball = packTarball(tempHome);
+      const openclawCli = join(repoRoot, "node_modules", "openclaw", "openclaw.mjs");
+      const env = isolatedOpenClawEnv(tempHome);
+
+      run(process.execPath, [openclawCli, "plugins", "install", tarball, "--force"], { env });
+      const inspectOutput = run(
+        process.execPath,
+        [openclawCli, "plugins", "inspect", "groupme", "--json", "--runtime"],
+        { env },
+      );
+      const inspected = JSON.parse(inspectOutput) as {
+        plugin?: {
+          id?: string;
+          packageName?: string;
+          status?: string;
+          channelIds?: string[];
+          configSchema?: boolean;
+          source?: string;
+          dependencyStatus?: {
+            requiredInstalled?: boolean;
+          };
+        };
+        shape?: string;
+        capabilities?: Array<{ kind?: string; ids?: string[] }>;
+        diagnostics?: unknown[];
+      };
+
+      expect(inspected.plugin).toEqual(
+        expect.objectContaining({
+          id: "groupme",
+          packageName: "openclaw-groupme",
+          status: "loaded",
+          channelIds: ["groupme"],
+          configSchema: true,
+        }),
+      );
+      expect(inspected.plugin?.source).toContain(".openclaw");
+      expect(inspected.plugin?.dependencyStatus?.requiredInstalled).toBe(true);
+      expect(inspected.shape).toBe("plain-capability");
+      expect(inspected.capabilities).toContainEqual({ kind: "channel", ids: ["groupme"] });
+      expect(
+        inspected.diagnostics?.filter((entry) => (entry as { level?: string }).level === "error"),
+      ).toEqual([]);
+    } finally {
+      removeTempProject(tempHome);
+    }
+  }, 120_000);
+});

--- a/tests/integration/package-contract.test.ts
+++ b/tests/integration/package-contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { packDryRun, readRootPackageJson } from "./helpers/package.js";
+
+function packedPaths(): Set<string> {
+  return new Set(packDryRun().files.map((file) => file.path));
+}
+
+describe("npm package contract", () => {
+  it("packs the files OpenClaw and ClawHub need to load the plugin", () => {
+    const paths = packedPaths();
+    const expectedFiles = [
+      "openclaw.plugin.json",
+      "dist/index.js",
+      "dist/setup-entry.js",
+      "dist/channel-plugin-api.js",
+      "dist/runtime-setter-api.js",
+      "dist/secret-contract-api.js",
+      "dist/setup-plugin-api.js",
+      "index.ts",
+      "channel-plugin-api.ts",
+      "runtime-setter-api.ts",
+      "secret-contract-api.ts",
+      "setup-entry.ts",
+      "setup-plugin-api.ts",
+      "src/channel.ts",
+      "src/groupme-api.ts",
+      "src/monitor.ts",
+      "src/onboarding.ts",
+      "src/secret-contract.ts",
+      "src/send.ts",
+    ];
+
+    for (const file of expectedFiles) {
+      expect(paths.has(file), `${file} should be included in npm pack`).toBe(true);
+    }
+  }, 60_000);
+
+  it("keeps manifest paths and compatibility aligned with OpenClaw v2026.6.1", () => {
+    const paths = packedPaths();
+    const pkg = readRootPackageJson();
+    const [extension] = pkg.openclaw.extensions;
+
+    expect(extension).toBe("./dist/index.js");
+    expect(pkg.openclaw.setupEntry).toBe("./dist/setup-entry.js");
+    expect(paths.has(extension.replace(/^\.\//, ""))).toBe(true);
+    expect(paths.has(pkg.openclaw.setupEntry.replace(/^\.\//, ""))).toBe(true);
+    expect(pkg.openclaw.compat.pluginApi).toBe(">=2026.6.1");
+    expect(pkg.peerDependencies.openclaw).toBe(">=2026.6.1");
+    expect(pkg.engines.node).toBe(">=22.19.0");
+  }, 60_000);
+
+  it("packages every explicit sidecar entrypoint declared in package.json#files", () => {
+    const paths = packedPaths();
+    const pkg = readRootPackageJson();
+    const sidecars = pkg.files.filter(
+      (entry) => entry.endsWith("-api.ts") || entry === "setup-entry.ts",
+    );
+
+    expect(sidecars).toEqual([
+      "channel-plugin-api.ts",
+      "runtime-setter-api.ts",
+      "secret-contract-api.ts",
+      "setup-entry.ts",
+      "setup-plugin-api.ts",
+    ]);
+
+    for (const sidecar of sidecars) {
+      expect(paths.has(sidecar), `${sidecar} source should be packed`).toBe(true);
+      expect(paths.has(`dist/${sidecar.replace(/\.ts$/, ".js")}`)).toBe(true);
+    }
+  }, 60_000);
+});

--- a/tests/integration/plugin-contract.test.ts
+++ b/tests/integration/plugin-contract.test.ts
@@ -1,0 +1,125 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
+import { describe, expect, it } from "vitest";
+import { importBuilt } from "./helpers/package.js";
+
+describe("built OpenClaw plugin contract", () => {
+  it("exposes the bundled channel entry through the packaged runtime entrypoint", async () => {
+    const mod = await importBuilt<{ default: Record<string, unknown> }>("dist/index.js");
+
+    expect(mod.default).toEqual(
+      expect.objectContaining({
+        kind: "bundled-channel-entry",
+        id: "groupme",
+        name: "GroupMe",
+        description: "GroupMe channel plugin",
+      }),
+    );
+    expect(mod.default.loadChannelPlugin).toBeTypeOf("function");
+    expect(mod.default.loadChannelSecrets).toBeTypeOf("function");
+    expect(mod.default.setChannelRuntime).toBeTypeOf("function");
+  });
+
+  it("exposes setup and channel sidecars OpenClaw can import directly", async () => {
+    const setup = await importBuilt<{ default: Record<string, unknown> }>("dist/setup-entry.js");
+    const channel = await importBuilt<{
+      groupmePlugin: {
+        id: string;
+        setupWizard?: unknown;
+        setup?: { validateInput?: unknown };
+        capabilities?: { chatTypes?: string[]; media?: boolean };
+        configSchema?: { runtime?: { safeParse?: unknown } };
+        gateway?: { startAccount?: unknown };
+        outbound?: { sendText?: unknown; sendMedia?: unknown };
+      };
+    }>("dist/channel-plugin-api.js");
+
+    expect(setup.default).toEqual(
+      expect.objectContaining({
+        kind: "bundled-channel-setup-entry",
+      }),
+    );
+    expect(channel.groupmePlugin.id).toBe("groupme");
+    expect(channel.groupmePlugin.capabilities).toEqual(
+      expect.objectContaining({
+        chatTypes: ["group"],
+        media: true,
+      }),
+    );
+    expect(channel.groupmePlugin.setupWizard).toBeDefined();
+    expect(channel.groupmePlugin.setup?.validateInput).toBeTypeOf("function");
+    expect(channel.groupmePlugin.configSchema?.runtime?.safeParse).toBeTypeOf("function");
+    expect(channel.groupmePlugin.gateway?.startAccount).toBeTypeOf("function");
+    expect(channel.groupmePlugin.outbound?.sendText).toBeTypeOf("function");
+    expect(channel.groupmePlugin.outbound?.sendMedia).toBeTypeOf("function");
+  });
+
+  it("accepts modern config with OpenClaw secret input references", async () => {
+    const { groupmePlugin } = await importBuilt<{
+      groupmePlugin: {
+        configSchema: {
+          runtime: {
+            safeParse(input: unknown): { success: boolean; error?: unknown };
+          };
+        };
+        config: {
+          resolveAccount(cfg: unknown, accountId?: string): { configured: boolean };
+          describeAccount(account: unknown): Record<string, unknown>;
+        };
+      };
+    }>("dist/channel-plugin-api.js");
+
+    const cfg = {
+      channels: {
+        groupme: {
+          enabled: true,
+          botId: { source: "env", provider: "default", id: "GROUPME_BOT_ID" },
+          accessToken: {
+            source: "env",
+            provider: "default",
+            id: "GROUPME_ACCESS_TOKEN",
+          },
+          callbackToken: {
+            source: "env",
+            provider: "default",
+            id: "GROUPME_CALLBACK_TOKEN",
+          },
+          groupId: "123456",
+          publicDomain: "https://example.test",
+          webhookPath: "/groupme",
+          requireMention: true,
+        },
+      },
+    };
+
+    expect(groupmePlugin.configSchema.runtime.safeParse(cfg.channels.groupme).success).toBe(true);
+
+    const account = groupmePlugin.config.resolveAccount(cfg, DEFAULT_ACCOUNT_ID);
+    expect(account.configured).toBe(true);
+    expect(groupmePlugin.config.describeAccount(account)).toEqual(
+      expect.objectContaining({
+        accountId: DEFAULT_ACCOUNT_ID,
+        botId: "***",
+        callbackToken: "***",
+        configured: true,
+        webhookPath: "/groupme",
+      }),
+    );
+  });
+
+  it("exposes the secret target registry sidecar", async () => {
+    const secrets = await importBuilt<{
+      channelSecrets: { secretTargetRegistryEntries: Array<{ id: string }> };
+    }>("dist/secret-contract-api.js");
+
+    expect(
+      secrets.channelSecrets.secretTargetRegistryEntries.map((entry) => entry.id).toSorted(),
+    ).toEqual([
+      "channels.groupme.accessToken",
+      "channels.groupme.accounts.*.accessToken",
+      "channels.groupme.accounts.*.botId",
+      "channels.groupme.accounts.*.callbackToken",
+      "channels.groupme.botId",
+      "channels.groupme.callbackToken",
+    ]);
+  });
+});

--- a/tests/integration/plugin-contract.test.ts
+++ b/tests/integration/plugin-contract.test.ts
@@ -17,7 +17,7 @@ describe("built OpenClaw plugin contract", () => {
     expect(mod.default.loadChannelPlugin).toBeTypeOf("function");
     expect(mod.default.loadChannelSecrets).toBeTypeOf("function");
     expect(mod.default.setChannelRuntime).toBeTypeOf("function");
-  });
+  }, 60_000);
 
   it("exposes setup and channel sidecars OpenClaw can import directly", async () => {
     const setup = await importBuilt<{ default: Record<string, unknown> }>("dist/setup-entry.js");
@@ -51,7 +51,7 @@ describe("built OpenClaw plugin contract", () => {
     expect(channel.groupmePlugin.gateway?.startAccount).toBeTypeOf("function");
     expect(channel.groupmePlugin.outbound?.sendText).toBeTypeOf("function");
     expect(channel.groupmePlugin.outbound?.sendMedia).toBeTypeOf("function");
-  });
+  }, 60_000);
 
   it("accepts modern config with OpenClaw secret input references", async () => {
     const { groupmePlugin } = await importBuilt<{
@@ -104,7 +104,7 @@ describe("built OpenClaw plugin contract", () => {
         webhookPath: "/groupme",
       }),
     );
-  });
+  }, 60_000);
 
   it("exposes the secret target registry sidecar", async () => {
     const secrets = await importBuilt<{
@@ -121,5 +121,5 @@ describe("built OpenClaw plugin contract", () => {
       "channels.groupme.botId",
       "channels.groupme.callbackToken",
     ]);
-  });
+  }, 60_000);
 });

--- a/tests/integration/webhook-flow.test.ts
+++ b/tests/integration/webhook-flow.test.ts
@@ -1,0 +1,262 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGroupMeWebhookHandler } from "../../src/monitor.js";
+import { setGroupMeRuntime } from "../../src/runtime.js";
+import type { CoreConfig, ResolvedGroupMeAccount } from "../../src/types.js";
+import { type NodeHandlerServer, startNodeHandlerServer } from "./helpers/http.js";
+
+type FakeCore = PluginRuntime & {
+  fns: {
+    activityRecord: ReturnType<typeof vi.fn>;
+    resolveAgentRoute: ReturnType<typeof vi.fn>;
+    recordInboundSession: ReturnType<typeof vi.fn>;
+    dispatchReplyWithBufferedBlockDispatcher: ReturnType<typeof vi.fn>;
+    finalizeInboundContext: ReturnType<typeof vi.fn>;
+  };
+};
+
+function buildCore(): FakeCore {
+  const fns = {
+    activityRecord: vi.fn(),
+    resolveAgentRoute: vi.fn(() => ({
+      agentId: "agent-main",
+      sessionKey: "groupme:group:g1",
+      accountId: "default",
+    })),
+    recordInboundSession: vi.fn(async () => undefined),
+    dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => undefined),
+    finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
+  };
+
+  return {
+    fns,
+    channel: {
+      activity: { record: fns.activityRecord },
+      routing: { resolveAgentRoute: fns.resolveAgentRoute },
+      mentions: { buildMentionRegexes: vi.fn(() => []) },
+      commands: { shouldHandleTextCommands: vi.fn(() => false) },
+      text: {
+        hasControlCommand: vi.fn(() => false),
+        chunkMarkdownText: vi.fn((text: string) => [text]),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+        formatAgentEnvelope: vi.fn((params: { body: string }) => `ENV:${params.body}`),
+        finalizeInboundContext: fns.finalizeInboundContext,
+        dispatchReplyWithBufferedBlockDispatcher: fns.dispatchReplyWithBufferedBlockDispatcher,
+      },
+      session: {
+        resolveStorePath: vi.fn(() => "/tmp/openclaw-groupme-integration-session"),
+        readSessionUpdatedAt: vi.fn(() => undefined),
+        recordInboundSession: fns.recordInboundSession,
+      },
+    },
+  } as unknown as FakeCore;
+}
+
+function buildRuntimeEnv(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (() => {
+      throw new Error("exit");
+    }) as RuntimeEnv["exit"],
+  };
+}
+
+function buildAccount(overrides: Partial<ResolvedGroupMeAccount> = {}): ResolvedGroupMeAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    botId: "bot-1",
+    accessToken: "token-1",
+    config: {
+      botId: "bot-1",
+      accessToken: "token-1",
+      callbackToken: "secret-token",
+      groupId: "g1",
+      webhookPath: "/groupme",
+      requireMention: false,
+      allowFrom: ["*"],
+      security: {
+        replay: {
+          ttlSeconds: 600,
+          maxEntries: 1000,
+        },
+        rateLimit: {
+          windowMs: 60_000,
+          maxRequestsPerIp: 20,
+          maxRequestsPerSender: 20,
+          maxConcurrent: 8,
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "msg-1",
+    text: "hello openclaw",
+    name: "Alice",
+    sender_type: "user",
+    sender_id: "user-1",
+    user_id: "user-1",
+    group_id: "g1",
+    source_guid: "source-1",
+    created_at: 1_700_000_000,
+    system: false,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+async function postCallback(baseUrl: string, body: unknown, token = "secret-token") {
+  return fetch(`${baseUrl}/groupme?k=${token}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GroupMe webhook flow integration", () => {
+  let server: NodeHandlerServer | null = null;
+
+  beforeEach(() => {
+    setGroupMeRuntime(buildCore());
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    server = null;
+  });
+
+  async function mount(
+    params: {
+      account?: ResolvedGroupMeAccount;
+      runtime?: RuntimeEnv;
+      statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+    } = {},
+  ) {
+    const runtime = params.runtime ?? buildRuntimeEnv();
+    const handler = createGroupMeWebhookHandler({
+      account: params.account ?? buildAccount(),
+      config: {} as CoreConfig,
+      runtime,
+      statusSink: params.statusSink,
+    });
+    server = await startNodeHandlerServer(handler);
+    return { baseUrl: server.baseUrl, runtime };
+  }
+
+  it("rejects non-POST and missing callback token at the HTTP boundary", async () => {
+    const { baseUrl } = await mount();
+
+    const getResponse = await fetch(`${baseUrl}/groupme`);
+    expect(getResponse.status).toBe(405);
+    expect(getResponse.headers.get("allow")).toBe("POST");
+
+    const missingTokenResponse = await fetch(`${baseUrl}/groupme`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload()),
+    });
+    expect(missingTokenResponse.status).toBe(404);
+  });
+
+  it("moves an authenticated callback through inbound session and reply dispatch", async () => {
+    const core = buildCore();
+    setGroupMeRuntime(core);
+    const statusSink = vi.fn();
+    const { baseUrl } = await mount({ statusSink });
+
+    const response = await postCallback(baseUrl, payload());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    await vi.waitFor(() => {
+      expect(core.fns.recordInboundSession).toHaveBeenCalledTimes(1);
+      expect(core.fns.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    });
+
+    const ctx = core.fns.finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(ctx).toEqual(
+      expect.objectContaining({
+        BodyForAgent: "hello openclaw",
+        From: "groupme:user:user-1",
+        To: "groupme:group:g1",
+        GroupSpace: "g1",
+        MessageSid: "msg-1",
+      }),
+    );
+    expect(statusSink).toHaveBeenCalledWith({ lastInboundAt: 1_700_000_000_000 });
+  });
+
+  it("acks ignored bot/system/empty callbacks without runtime dispatch", async () => {
+    const core = buildCore();
+    setGroupMeRuntime(core);
+    const { baseUrl } = await mount();
+
+    for (const ignored of [
+      payload({ id: "bot-msg", source_guid: "bot-guid", sender_type: "bot" }),
+      payload({ id: "system-msg", source_guid: "system-guid", system: true }),
+      payload({ id: "empty-msg", source_guid: "empty-guid", text: " " }),
+    ]) {
+      const response = await postCallback(baseUrl, ignored);
+      expect(response.status).toBe(200);
+    }
+
+    expect(core.fns.recordInboundSession).not.toHaveBeenCalled();
+    expect(core.fns.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates replayed payloads and rejects wrong group ids", async () => {
+    const core = buildCore();
+    setGroupMeRuntime(core);
+    const { baseUrl } = await mount();
+    const replay = payload({ id: "replay", source_guid: "replay-guid" });
+
+    expect((await postCallback(baseUrl, replay)).status).toBe(200);
+    expect((await postCallback(baseUrl, replay)).status).toBe(200);
+    expect((await postCallback(baseUrl, payload({ group_id: "wrong" }))).status).toBe(403);
+
+    await vi.waitFor(() => {
+      expect(core.fns.recordInboundSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("enforces per-sender rate limiting before inbound dispatch", async () => {
+    const core = buildCore();
+    setGroupMeRuntime(core);
+    const { baseUrl } = await mount({
+      account: buildAccount({
+        config: {
+          ...buildAccount().config,
+          security: {
+            ...buildAccount().config.security,
+            rateLimit: {
+              windowMs: 60_000,
+              maxRequestsPerIp: 20,
+              maxRequestsPerSender: 1,
+              maxConcurrent: 8,
+            },
+          },
+        },
+      }),
+    });
+
+    expect((await postCallback(baseUrl, payload({ id: "rate-1", source_guid: "r1" }))).status).toBe(
+      200,
+    );
+    expect((await postCallback(baseUrl, payload({ id: "rate-2", source_guid: "r2" }))).status).toBe(
+      429,
+    );
+
+    await vi.waitFor(() => {
+      expect(core.fns.recordInboundSession).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/live/groupme-api-live.test.ts
+++ b/tests/live/groupme-api-live.test.ts
@@ -18,7 +18,7 @@ async function readError(response: Response): Promise<string> {
   return `${response.status} ${response.statusText}${text ? `: ${text}` : ""}`;
 }
 
-describeLive("GroupMe live smoke", () => {
+describeLive("GroupMe API live smoke", () => {
   it("can read the configured group and post through the configured bot", async () => {
     const accessToken = readSecret("GROUPME_LIVE_ACCESS_TOKEN");
     const botId = readSecret("GROUPME_LIVE_BOT_ID");
@@ -42,7 +42,7 @@ describeLive("GroupMe live smoke", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         bot_id: botId,
-        text: `openclaw-groupme live smoke ${runId}`,
+        text: `openclaw-groupme api live smoke ${runId}`,
       }),
     });
 

--- a/tests/live/groupme-live.test.ts
+++ b/tests/live/groupme-live.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+const requiredSecrets = [
+  "GROUPME_LIVE_ACCESS_TOKEN",
+  "GROUPME_LIVE_BOT_ID",
+  "GROUPME_LIVE_GROUP_ID",
+] as const;
+
+function readSecret(name: (typeof requiredSecrets)[number]): string {
+  return process.env[name]?.trim() ?? "";
+}
+
+const hasLiveSecrets = requiredSecrets.every((name) => readSecret(name));
+const describeLive = hasLiveSecrets ? describe : describe.skip;
+
+async function readError(response: Response): Promise<string> {
+  const text = await response.text();
+  return `${response.status} ${response.statusText}${text ? `: ${text}` : ""}`;
+}
+
+describeLive("GroupMe live smoke", () => {
+  it("can read the configured group and post through the configured bot", async () => {
+    const accessToken = readSecret("GROUPME_LIVE_ACCESS_TOKEN");
+    const botId = readSecret("GROUPME_LIVE_BOT_ID");
+    const groupId = readSecret("GROUPME_LIVE_GROUP_ID");
+
+    const groupUrl = new URL(`https://api.groupme.com/v3/groups/${groupId}`);
+    groupUrl.searchParams.set("token", accessToken);
+
+    const groupResponse = await fetch(groupUrl);
+    expect(groupResponse.ok, await readError(groupResponse)).toBe(true);
+
+    const groupPayload = (await groupResponse.json()) as { response?: { id?: unknown } };
+    expect(String(groupPayload.response?.id ?? "")).toBe(groupId);
+
+    const runId =
+      process.env.GITHUB_RUN_ID?.trim() ||
+      process.env.GITHUB_SHA?.slice(0, 12) ||
+      `local-${Date.now()}`;
+    const postResponse = await fetch("https://api.groupme.com/v3/bots/post", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bot_id: botId,
+        text: `openclaw-groupme live smoke ${runId}`,
+      }),
+    });
+
+    expect(postResponse.status, await readError(postResponse)).toBe(202);
+  }, 30_000);
+});

--- a/tests/live/groupme-plugin-outbound-live.test.ts
+++ b/tests/live/groupme-plugin-outbound-live.test.ts
@@ -1,0 +1,171 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createTempProject,
+  packTarball,
+  removeTempProject,
+  repoRoot,
+  run,
+} from "../integration/helpers/package.js";
+
+const requiredSecrets = [
+  "GROUPME_LIVE_ACCESS_TOKEN",
+  "GROUPME_LIVE_BOT_ID",
+  "GROUPME_LIVE_GROUP_ID",
+] as const;
+
+function readSecret(name: (typeof requiredSecrets)[number]): string {
+  return process.env[name]?.trim() ?? "";
+}
+
+function isolatedOpenClawEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    CODEX_HOME: home,
+    NO_COLOR: "1",
+    OPENCLAW_DISABLE_BONJOUR: "1",
+    GROUPME_LIVE_ACCESS_TOKEN: readSecret("GROUPME_LIVE_ACCESS_TOKEN"),
+    GROUPME_LIVE_BOT_ID: readSecret("GROUPME_LIVE_BOT_ID"),
+    GROUPME_LIVE_GROUP_ID: readSecret("GROUPME_LIVE_GROUP_ID"),
+    VITEST: "",
+    VITEST_WORKER_ID: "",
+  };
+}
+
+const hasLiveSecrets = requiredSecrets.every((name) => readSecret(name));
+const describeLive = hasLiveSecrets ? describe : describe.skip;
+
+describeLive("GroupMe plugin outbound live smoke", () => {
+  it("sends through an installed OpenClaw channel plugin using env SecretRefs", () => {
+    const tempHome = createTempProject("openclaw-groupme-plugin-live-");
+    try {
+      const tarball = packTarball(tempHome);
+      const openclawCli = join(repoRoot, "node_modules", "openclaw", "openclaw.mjs");
+      const env = isolatedOpenClawEnv(tempHome);
+      const groupId = readSecret("GROUPME_LIVE_GROUP_ID");
+      const runId =
+        process.env.GITHUB_RUN_ID?.trim() ||
+        process.env.GITHUB_SHA?.slice(0, 12) ||
+        `local-${Date.now()}`;
+
+      run(process.execPath, [openclawCli, "plugins", "install", tarball, "--force"], { env });
+      run(
+        process.execPath,
+        [
+          openclawCli,
+          "channels",
+          "add",
+          "--channel",
+          "groupme",
+          "--token",
+          "placeholder",
+          "--account",
+          "default",
+          "--name",
+          "Live Smoke",
+        ],
+        { env },
+      );
+      run(
+        process.execPath,
+        [
+          openclawCli,
+          "config",
+          "set",
+          "channels.groupme.botId",
+          "--ref-source",
+          "env",
+          "--ref-provider",
+          "default",
+          "--ref-id",
+          "GROUPME_LIVE_BOT_ID",
+        ],
+        { env },
+      );
+      run(
+        process.execPath,
+        [
+          openclawCli,
+          "config",
+          "set",
+          "channels.groupme.accessToken",
+          "--ref-source",
+          "env",
+          "--ref-provider",
+          "default",
+          "--ref-id",
+          "GROUPME_LIVE_ACCESS_TOKEN",
+        ],
+        { env },
+      );
+      run(
+        process.execPath,
+        [
+          openclawCli,
+          "config",
+          "set",
+          "channels.groupme.groupId",
+          JSON.stringify(groupId),
+          "--strict-json",
+        ],
+        { env },
+      );
+
+      const configOutput = run(
+        process.execPath,
+        [openclawCli, "config", "get", "channels.groupme", "--json"],
+        { env },
+      );
+      const config = JSON.parse(configOutput) as {
+        botId?: unknown;
+        accessToken?: unknown;
+        groupId?: unknown;
+      };
+      expect(config.botId).toEqual({
+        source: "env",
+        provider: "default",
+        id: "GROUPME_LIVE_BOT_ID",
+      });
+      expect(config.accessToken).toEqual({
+        source: "env",
+        provider: "default",
+        id: "GROUPME_LIVE_ACCESS_TOKEN",
+      });
+      expect(config.groupId).toBe(groupId);
+
+      const sendOutput = run(
+        process.execPath,
+        [
+          openclawCli,
+          "message",
+          "send",
+          "--channel",
+          "groupme",
+          "--target",
+          groupId,
+          "--message",
+          `openclaw-groupme plugin outbound live smoke ${runId}`,
+          "--json",
+        ],
+        { env },
+      );
+      const send = JSON.parse(sendOutput) as {
+        action?: string;
+        channel?: string;
+        dryRun?: boolean;
+        messageId?: string;
+      };
+      expect(send).toEqual(
+        expect.objectContaining({
+          action: "send",
+          channel: "groupme",
+          dryRun: false,
+        }),
+      );
+      expect(send.messageId).toEqual(expect.any(String));
+    } finally {
+      removeTempProject(tempHome);
+    }
+  }, 120_000);
+});

--- a/tests/unit/accounts.test.ts
+++ b/tests/unit/accounts.test.ts
@@ -6,8 +6,8 @@ import {
   readTrimmed,
   resolveDefaultGroupMeAccountId,
   resolveGroupMeAccount,
-} from "../src/accounts.js";
-import type { CoreConfig, GroupMeConfig } from "../src/types.js";
+} from "../../src/accounts.js";
+import type { CoreConfig, GroupMeConfig } from "../../src/types.js";
 
 function cfg(groupme: GroupMeConfig): CoreConfig {
   return { channels: { groupme } } as CoreConfig;

--- a/tests/unit/channel.test.ts
+++ b/tests/unit/channel.test.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setGroupMeRuntime } from "../src/runtime.js";
-import type { CoreConfig, ResolvedGroupMeAccount } from "../src/types.js";
+import { setGroupMeRuntime } from "../../src/runtime.js";
+import type { CoreConfig, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const registerPluginHttpRouteMock = vi.hoisted(() => vi.fn());
 const sendGroupMeTextMock = vi.hoisted(() => vi.fn());
@@ -12,8 +12,8 @@ vi.mock("openclaw/plugin-sdk/webhook-ingress", () => ({
   registerPluginHttpRoute: registerPluginHttpRouteMock,
 }));
 
-vi.mock("../src/send.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/send.js")>();
+vi.mock("../../src/send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/send.js")>();
   return {
     ...actual,
     sendGroupMeText: sendGroupMeTextMock,
@@ -21,7 +21,7 @@ vi.mock("../src/send.js", async (importOriginal) => {
   };
 });
 
-import { groupmePlugin } from "../src/channel.js";
+import { groupmePlugin } from "../../src/channel.js";
 
 function cfg(groupme: CoreConfig["channels"]["groupme"]): CoreConfig {
   return { channels: { groupme } } as CoreConfig;

--- a/tests/unit/groupme-api.test.ts
+++ b/tests/unit/groupme-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createBot, fetchGroups } from "../src/groupme-api.js";
+import { createBot, fetchGroups } from "../../src/groupme-api.js";
 
 function makeGroup(id: string, name: string) {
   return {

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -5,7 +5,7 @@ import {
   formatGroupMeHistoryEntry,
   resolveGroupMeBodyForAgent,
   resolveGroupMeHistoryLimit,
-} from "../src/history.js";
+} from "../../src/history.js";
 
 describe("resolveGroupMeHistoryLimit", () => {
   it("uses default when unset", () => {

--- a/tests/unit/inbound.command-bypass.test.ts
+++ b/tests/unit/inbound.command-bypass.test.ts
@@ -1,6 +1,6 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../src/types.js";
+import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -51,11 +51,11 @@ const core = vi.hoisted(() => {
   };
 });
 
-vi.mock("../src/runtime.js", () => ({
+vi.mock("../../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-import { handleGroupMeInbound } from "../src/inbound.js";
+import { handleGroupMeInbound } from "../../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/unit/inbound.context.test.ts
+++ b/tests/unit/inbound.context.test.ts
@@ -1,6 +1,6 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../src/types.js";
+import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -51,11 +51,11 @@ const core = vi.hoisted(() => {
   };
 });
 
-vi.mock("../src/runtime.js", () => ({
+vi.mock("../../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-import { handleGroupMeInbound } from "../src/inbound.js";
+import { handleGroupMeInbound } from "../../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/unit/inbound.delivery.test.ts
+++ b/tests/unit/inbound.delivery.test.ts
@@ -1,7 +1,7 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/core";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../src/types.js";
+import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -60,12 +60,12 @@ const core = vi.hoisted(() => {
 const sendGroupMeTextMock = vi.hoisted(() => vi.fn());
 const sendGroupMeMediaMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../src/runtime.js", () => ({
+vi.mock("../../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-vi.mock("../src/send.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/send.js")>();
+vi.mock("../../src/send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/send.js")>();
   return {
     ...actual,
     sendGroupMeText: sendGroupMeTextMock,
@@ -79,7 +79,7 @@ type DispatcherParams = {
   };
 };
 
-import { handleGroupMeInbound } from "../src/inbound.js";
+import { handleGroupMeInbound } from "../../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/unit/inbound.history-buffer.test.ts
+++ b/tests/unit/inbound.history-buffer.test.ts
@@ -1,6 +1,6 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../src/types.js";
+import type { CoreConfig, GroupMeCallbackData, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const core = vi.hoisted(() => {
   const fns = {
@@ -51,11 +51,11 @@ const core = vi.hoisted(() => {
   };
 });
 
-vi.mock("../src/runtime.js", () => ({
+vi.mock("../../src/runtime.js", () => ({
   getGroupMeRuntime: () => core.runtime,
 }));
 
-import { handleGroupMeInbound } from "../src/inbound.js";
+import { handleGroupMeInbound } from "../../src/inbound.js";
 
 function buildRuntimeEnv(): RuntimeEnv {
   return {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import plugin from "../index.js";
+import plugin from "../../index.js";
 
 describe("GroupMe bundled channel entry", () => {
   it("defines the bundled channel entry", () => {

--- a/tests/unit/monitor.test.ts
+++ b/tests/unit/monitor.test.ts
@@ -3,15 +3,15 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { describe, expect, it, vi } from "vitest";
-import type { CoreConfig, ResolvedGroupMeAccount } from "../src/types.js";
+import type { CoreConfig, ResolvedGroupMeAccount } from "../../src/types.js";
 
 const handleGroupMeInboundMock = vi.hoisted(() => vi.fn(async (_params: unknown) => undefined));
 
-vi.mock("../src/inbound.js", () => ({
+vi.mock("../../src/inbound.js", () => ({
   handleGroupMeInbound: handleGroupMeInboundMock,
 }));
 
-import { createGroupMeWebhookHandler } from "../src/monitor.js";
+import { createGroupMeWebhookHandler } from "../../src/monitor.js";
 
 async function withServer(
   handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -4,7 +4,7 @@ import {
   normalizeGroupMeAllowEntry,
   normalizeGroupMeTarget,
   normalizeStringId,
-} from "../src/normalize.js";
+} from "../../src/normalize.js";
 
 describe("groupme normalize", () => {
   it("normalizes string ids", () => {

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -6,12 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const fetchGroupsMock = vi.hoisted(() => vi.fn());
 const createBotMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../src/groupme-api.js", () => ({
+vi.mock("../../src/groupme-api.js", () => ({
   fetchGroups: fetchGroupsMock,
   createBot: createBotMock,
 }));
 
-import { groupmeOnboardingAdapter } from "../src/onboarding.js";
+import { groupmeOnboardingAdapter } from "../../src/onboarding.js";
 
 function configureWhenConfigured(
   params: Parameters<NonNullable<typeof groupmeOnboardingAdapter.configureWhenConfigured>>[0],

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -4,7 +4,7 @@ import {
   extractImageUrls,
   parseGroupMeCallback,
   shouldProcessCallback,
-} from "../src/parse.js";
+} from "../../src/parse.js";
 
 const validPayload = {
   id: "msg-1",

--- a/tests/unit/policy.test.ts
+++ b/tests/unit/policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSenderAccess } from "../src/policy.js";
+import { resolveSenderAccess } from "../../src/policy.js";
 
 describe("resolveSenderAccess", () => {
   it("allows all when allowFrom is empty", () => {

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GroupMeRateLimiter } from "../src/rate-limit.js";
+import { GroupMeRateLimiter } from "../../src/rate-limit.js";
 
 describe("GroupMeRateLimiter", () => {
   it("enforces per-ip threshold", () => {

--- a/tests/unit/replay-cache.test.ts
+++ b/tests/unit/replay-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildReplayKey, GroupMeReplayCache } from "../src/replay-cache.js";
-import type { GroupMeCallbackData } from "../src/types.js";
+import { buildReplayKey, GroupMeReplayCache } from "../../src/replay-cache.js";
+import type { GroupMeCallbackData } from "../../src/types.js";
 
 describe("GroupMeReplayCache", () => {
   it("accepts first key and rejects duplicate within ttl", () => {

--- a/tests/unit/secret-contract.test.ts
+++ b/tests/unit/secret-contract.test.ts
@@ -4,7 +4,7 @@ import {
   channelSecrets,
   collectRuntimeConfigAssignments,
   secretTargetRegistryEntries,
-} from "../src/secret-contract.js";
+} from "../../src/secret-contract.js";
 
 function envRef(name: string) {
   return { source: "env", provider: "default", id: name };

--- a/tests/unit/security.test.ts
+++ b/tests/unit/security.test.ts
@@ -5,8 +5,8 @@ import {
   resolveGroupMeSecurity,
   validateProxyRequest,
   verifyCallbackAuth,
-} from "../src/security.js";
-import type { GroupMeAccountConfig } from "../src/types.js";
+} from "../../src/security.js";
+import type { GroupMeAccountConfig } from "../../src/types.js";
 
 function buildSecurity(config?: GroupMeAccountConfig) {
   return resolveGroupMeSecurity(config ?? {});

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { setGroupMeRuntime } from "../src/runtime.js";
+import { setGroupMeRuntime } from "../../src/runtime.js";
 import {
   sendGroupMeMedia,
   sendGroupMeMessage,
   sendGroupMeText,
   uploadGroupMeImage,
-} from "../src/send.js";
-import type { CoreConfig } from "../src/types.js";
+} from "../../src/send.js";
+import type { CoreConfig } from "../../src/types.js";
 
 describe("sendGroupMeMessage", () => {
   it("sends text message", async () => {

--- a/tests/unit/setup.test.ts
+++ b/tests/unit/setup.test.ts
@@ -2,8 +2,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/setup";
 import { describe, expect, it } from "vitest";
-import { groupmePlugin } from "../src/channel.js";
-import type { GroupMeConfig } from "../src/types.js";
+import { groupmePlugin } from "../../src/channel.js";
+import type { GroupMeConfig } from "../../src/types.js";
 
 function requireSetup(): ChannelSetupAdapter {
   if (!groupmePlugin.setup) {


### PR DESCRIPTION
## Summary

- split the test suite into unit, integration, and live smoke categories
- add package, install, plugin contract, OpenClaw CLI, webhook-flow, onboarding, and GroupMe HTTP-boundary integration coverage
- add manual live smoke workflow for dedicated GroupMe credentials
- update the integration testing plan with implementation status and remaining optional expansions

## Verification

- npm run check
- npm run test:coverage
- npm run test:live (skips without local secrets)

## Notes

The permanent live smoke workflow cannot be manually dispatched until this workflow file exists on the default branch. A temporary workflow already verified the configured GroupMe secrets can fetch the test group and post through the bot.