### PR TITLE
ci: clarify GroupMe live smoke workflow name

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,4 +1,4 @@
-name: Live Smoke
+name: GroupMe Live API and Plugin Smoke
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Rename the manual live smoke workflow from Live Smoke to GroupMe Live API and Plugin Smoke so the Actions list is self-explanatory.
- Disabled the stale GroupMe Live Secret Smoke workflow registration in GitHub Actions because its workflow file no longer exists on main.

## Verification

- 
pm run check passed via pre-push hook.