### PR TITLE
feat!: modernize GroupMe channel for OpenClaw 2026.6.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,7 +116,7 @@ For example, a breaking modernization PR should be squash-merged with a title li
 feat!: modernize GroupMe channel for OpenClaw 2026.6.1
 ```
 
-Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will skip it as non-user-facing.
+Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will not recognize it as a release-triggering Conventional Commit and will skip the release.
 
 ## Dependencies
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,24 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 
 Only `feat:`, `fix:`, and breaking changes trigger a release. Use the appropriate type so the changelog and version bump are correct.
 
+### Release Please and Squash Merges
+
+Release Please reads the commits that land on `main`. When GitHub squash-merges a pull request, the PR title usually becomes the final commit subject. If a PR contains release-triggering work, the PR title used for squash merge must also be a Conventional Commit.
+
+Before merging a PR that should trigger a release, make sure the squash commit title starts with one of:
+
+- `feat:` for new features
+- `fix:` for bug fixes
+- `feat!:` or another Conventional Commit with `!` for breaking changes
+
+For example, a breaking modernization PR should be squash-merged with a title like:
+
+```text
+feat!: modernize GroupMe channel for OpenClaw 2026.6.1
+```
+
+Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will skip it as non-user-facing.
+
 ## Dependencies
 
 - **`zod`** (runtime) — config schema validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ For example, a breaking modernization PR should be squash-merged with a title li
 feat!: modernize GroupMe channel for OpenClaw 2026.6.1
 ```
 
-Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will skip it as non-user-facing.
+Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will not recognize it as a release-triggering Conventional Commit and will skip the release.
 
 ## ClawHub Publishing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,24 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 
 Only `feat:`, `fix:`, and breaking changes trigger a release. Use the appropriate type so the changelog and version bump are correct.
 
+### Release Please and Squash Merges
+
+Release Please reads the commits that land on `main`. When GitHub squash-merges a pull request, the PR title usually becomes the final commit subject. If a PR contains release-triggering work, the PR title used for squash merge must also be a Conventional Commit.
+
+Before merging a PR that should trigger a release, make sure the squash commit title starts with one of:
+
+- `feat:` for new features
+- `fix:` for bug fixes
+- `feat!:` or another Conventional Commit with `!` for breaking changes
+
+For example, a breaking modernization PR should be squash-merged with a title like:
+
+```text
+feat!: modernize GroupMe channel for OpenClaw 2026.6.1
+```
+
+Do not squash-merge a releasable PR with a descriptive but non-conventional title such as `Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling`, because Release Please will skip it as non-user-facing.
+
 ## ClawHub Publishing
 
 This is a ClawHub **code plugin**, not a skills plugin. Publish the same npm package artifact to ClawHub with `clawhub package publish --family code-plugin`.


### PR DESCRIPTION
## Summary

- Add an explicit release-marker commit for PR #56, which contained the OpenClaw 2026.6.1 modernization but was squash-merged with a non-conventional title.
- Update AGENTS.md and .claude/CLAUDE.md so future releasable squash merges keep a Conventional Commit PR title.

## Why

Release Please reads commits on main. PR #56 had release-triggering commits on its branch, but the squash commit on main was titled \Modernize GroupMe for OpenClaw 2026.6.1 and add repo tooling (#56)\, so Release Please could not parse it and skipped the release.

## Merge requirement

Please keep this PR's squash commit title as:

\eat!: modernize GroupMe channel for OpenClaw 2026.6.1\

That is the release marker Release Please needs.

## Verification

- \
pm run lint\
- \
pm run check\ passed via pre-push hook