### PR TITLE
ci: fix ClawHub pack step broken by lifecycle script output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,11 @@ jobs:
       - name: Pack package for ClawHub
         id: pack
         run: |
-          npm pack --json > pack-result.json
+          # Build explicitly, then pack with --ignore-scripts so lifecycle
+          # output (e.g. `prepare`/lefthook writing to stdout) cannot pollute
+          # the JSON we parse for the tarball filename.
+          npm run build
+          npm pack --json --ignore-scripts > pack-result.json
           TARBALL="$(
             node -e "const fs = require('node:fs'); const packed = JSON.parse(fs.readFileSync('pack-result.json', 'utf8')); const filename = packed[0]?.filename; if (!filename) { console.error('npm pack did not report a tarball filename.'); process.exit(1); } process.stdout.write(filename);"
           )"


### PR DESCRIPTION
## Problem

The **0.5.0** Release Please run ([run 27096221362](https://github.com/oddrationale/openclaw-groupme/actions/runs/27096221362)) **published to npm successfully** (`openclaw-groupme@0.5.0` with provenance) but then **failed at the "Pack package for ClawHub" step**, so 0.5.0 never reached ClawHub.

```
> openclaw-groupme@0.5.0 prepare
> lefthook install
sync hooks: ✔️(commit-msg, pre-push, pre-commit)
SyntaxError: Unexpected token 's', "sync hooks"... is not valid JSON
```

### Root cause

The step runs `npm pack --json > pack-result.json` and then `JSON.parse`s the file. But `npm pack` runs lifecycle scripts — `prepack` (`npm run build`) and **`prepare` (`lefthook install`)**. `lefthook install` writes `sync hooks: ✔️(…)` to **stdout**, which gets captured into `pack-result.json` alongside the JSON, so `JSON.parse` fails.

This is the first release since `lefthook` (the `prepare` script) was added, which is why it surfaced now. The earlier `npm publish` step survived only because it doesn't parse pack's stdout.

## Fix

Build explicitly, then pack with `--ignore-scripts` so no lifecycle output can pollute the JSON (the tarball still includes `dist/**` because the build ran):

```yaml
npm run build
npm pack --json --ignore-scripts > pack-result.json
```

## Note on 0.5.0

Because `npm publish` already succeeded, 0.5.0 is on npm but **not on ClawHub**. After this lands, re-running this workflow won't re-trigger (it's gated on `release_created`), so 0.5.0 will need a manual ClawHub publish, e.g.:

```bash
TARBALL="$(npm pack)"
npx --yes clawhub@0.19.1 login --token "$CLAWHUB_TOKEN"
npx --yes clawhub@0.19.1 package publish "./$TARBALL" --family code-plugin \
  --manual-override-reason "manual 0.5.0 ClawHub publish after pack-step fix"
```

The fix ensures the **next** release publishes to ClawHub automatically.

https://claude.ai/code/session_018xu2nBggoQM7wDRZewKqua

---
_Generated by [Claude Code](https://claude.ai/code/session_018xu2nBggoQM7wDRZewKqua)_