### PR TITLE
fix: validate ClawHub publish before npm publish in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,9 +44,11 @@ jobs:
       - name: Show package version
         run: npm pkg get name version
 
-      - name: Publish package
-        run: npm publish --provenance --access public
-
+      # Pack and validate the ClawHub publish (the weakest link) BEFORE the
+      # irreversible npm publish. npm rejects re-publishing an existing version,
+      # so if ClawHub fails after npm succeeds the release is stuck. By packing
+      # and dry-running ClawHub first, a ClawHub-side problem fails the job
+      # before anything is published, leaving the release safe to re-run.
       - name: Pack package for ClawHub
         id: pack
         run: |
@@ -64,7 +66,7 @@ jobs:
           fi
           echo "tarball=${TARBALL}" >> "${GITHUB_OUTPUT}"
 
-      - name: Publish package to ClawHub
+      - name: Validate ClawHub publish (dry run)
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
@@ -72,6 +74,22 @@ jobs:
             echo "::error::CLAWHUB_TOKEN secret is required to publish to ClawHub."
             exit 1
           fi
+          npx --yes clawhub@0.19.1 login --token "${CLAWHUB_TOKEN}"
+          npx --yes clawhub@0.19.1 package publish "${{ steps.pack.outputs.tarball }}" \
+            --family code-plugin \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --source-commit "${GITHUB_SHA}" \
+            --source-ref "${GITHUB_REF}" \
+            --manual-override-reason "GitHub Actions release publish via CLAWHUB_TOKEN" \
+            --dry-run
+
+      - name: Publish package to npm
+        run: npm publish --provenance --access public
+
+      - name: Publish package to ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
           npx --yes clawhub@0.19.1 login --token "${CLAWHUB_TOKEN}"
           npx --yes clawhub@0.19.1 package publish "${{ steps.pack.outputs.tarball }}" \
             --family code-plugin \


### PR DESCRIPTION
## Why

Two goals in one change:

1. **Harden the release pipeline** so ClawHub — the weakest link — is validated *before* the irreversible npm publish.
2. **Cut a fresh release (0.5.1)** so the package is published to **both npm and ClawHub** through the hardened pipeline. (0.5.0 reached npm but not ClawHub due to the pack bug fixed in #65.)

## The problem with the old ordering

`npm publish` is irreversible (a version can't be re-published), but it ran **before** the ClawHub publish. So when ClawHub failed, the release was stuck: npm was done, ClawHub wasn't, and re-running the job failed on the npm duplicate-version error.

## New ordering

1. **Pack** the tarball (`npm pack --ignore-scripts`).
2. **Validate ClawHub (dry run)** — `clawhub login` + `clawhub package publish … --dry-run`. A ClawHub-side problem (bad tarball, missing `openclaw.plugin.json`, auth, family) now fails the job **before anything ships**.
3. **Publish to npm** (`npm publish --provenance`) — the irreversible step, only after ClawHub validates.
4. **Publish to ClawHub** for real.

Why not publish ClawHub-real first? That just flips the stuck case (ClawHub ahead, npm behind, and a re-run can hit a ClawHub duplicate-version rejection). Validating the weak link via dry-run, then doing the reliable npm publish, then the real ClawHub publish, is the safest sequence.

**Caveat:** two registries can't be fully atomic. The dry-run makes "npm succeeds, ClawHub real-publish fails" unlikely (creds + tarball already validated), but if a transient ClawHub error hits step 4, npm would be ahead — recoverable with a one-time manual `clawhub package publish` for that version.

## Release mechanics

This is typed `fix:`, so merging it makes Release Please open a **0.5.1** release PR. Merging *that* runs this hardened workflow (read from `main`), publishing 0.5.1 to npm + ClawHub.

> **Merge note:** squash-merge with the `fix:` title preserved so Release Please recognizes it as a release-triggering commit.

https://claude.ai/code/session_018xu2nBggoQM7wDRZewKqua

---
_Generated by [Claude Code](https://claude.ai/code/session_018xu2nBggoQM7wDRZewKqua)_